### PR TITLE
Generate xml

### DIFF
--- a/src/oob/exchange.rs
+++ b/src/oob/exchange.rs
@@ -78,6 +78,7 @@ impl PublisherRequest {
         })
     }
 
+    /// Encodes a <publisher_request> to a Vec
     pub fn encode_vec(&self) -> Vec<u8> {
         XmlWriter::encode_vec(|w| {
 
@@ -247,6 +248,7 @@ impl RepositoryResponse {
         })
     }
 
+    /// Encodes the <repository_response/> to a Vec
     pub fn encode_vec(&self) -> Vec<u8> {
         XmlWriter::encode_vec(|w| {
 

--- a/src/oob/exchange.rs
+++ b/src/oob/exchange.rs
@@ -47,7 +47,7 @@ impl PublisherRequest {
             r.take_named_element("publisher_request", |mut a, r| {
                 match a.take_req("version") {
                     Ok(s) => {
-                        if s != "1".to_string() {
+                        if s != "1" {
                             return Err(PublisherRequestError::InvalidVersion)
                         }
                     }

--- a/src/oob/exchange.rs
+++ b/src/oob/exchange.rs
@@ -246,6 +246,53 @@ impl RepositoryResponse {
             })
         })
     }
+
+    pub fn encode_vec(&self) -> Vec<u8> {
+        XmlWriter::encode_vec(|w| {
+
+            let service_uri = self.service_uri.to_string();
+            let sia_base = self.sia_base.to_string();
+            let rrdp_notification_uri = self.rrdp_notification_uri.to_string();
+
+            let mut attr = vec![
+                AttributePair::from(
+                    "version",
+                    "1"),
+                AttributePair::from(
+                    "publisher_handle",
+                    self.publisher_handle.as_ref()),
+                AttributePair::from(
+                    "service_uri",
+                    service_uri.as_ref()),
+                AttributePair::from(
+                    "sia_base",
+                    sia_base.as_ref()),
+                AttributePair::from(
+                    "rrdp_notification_uri",
+                    rrdp_notification_uri.as_ref()),
+            ];
+            if let Some(ref t) = self.tag {
+                attr.push(AttributePair::from(
+                    "tag",
+                    t));
+            }
+
+            w.put_first_element_with_attributes(
+                "repository_response",
+                "http://www.hactrn.net/uris/rpki/rpki-setup/",
+                attr,
+                |w| {
+                    w.put_element(
+                        "repository_bpki_ta",
+                        |w| {
+                            w.put_blob(&self.id_cert.to_bytes())
+                        }
+                    )
+                }
+
+            )
+        })
+    }
 }
 
 
@@ -326,6 +373,21 @@ mod tests {
     use time;
     use chrono::{TimeZone, Utc};
 
+    fn example_rrdp_uri() -> uri::Http {
+        uri::Http::from_str(
+            "https://rpki.example/rrdp/notify.xml").unwrap()
+    }
+
+    fn example_sia_base() -> uri::Rsync {
+        uri::Rsync::from_str(
+            "rsync://a.example/rpki/Alice/Bob-42/").unwrap()
+    }
+
+    fn example_service_uri() -> uri::Http {
+        uri::Http::from_str(
+            "http://a.example/publication/Alice/Bob-42").unwrap()
+    }
+
     #[test]
     fn should_parse_publisher_request() {
         let d = Utc.ymd(2012, 1, 1).and_hms(0, 0, 0);
@@ -347,18 +409,9 @@ mod tests {
             let rr = RepositoryResponse::decode(xml.as_bytes()).unwrap();
             assert_eq!(Some("A0001".to_string()), rr.tag);
             assert_eq!("Alice/Bob-42".to_string(), rr.publisher_handle);
-            assert_eq!(
-                uri::Http::from_str(
-                    "http://a.example/publication/Alice/Bob-42").unwrap(),
-                rr.service_uri);
-            assert_eq!(
-                uri::Http::from_str(
-                    "https://rpki.example/rrdp/notify.xml").unwrap(),
-                rr.rrdp_notification_uri);
-            assert_eq!(
-                uri::Rsync::from_str(
-                    "rsync://a.example/rpki/Alice/Bob-42/").unwrap(),
-                rr.sia_base);
+            assert_eq!(example_service_uri(), rr.service_uri);
+            assert_eq!(example_rrdp_uri(), rr.rrdp_notification_uri);
+            assert_eq!(example_sia_base(), rr.sia_base);
 
             assert!(rr.id_cert.validate_ta().is_ok());
         });
@@ -381,5 +434,27 @@ mod tests {
             PublisherRequest::decode(str::from_utf8(&enc).unwrap().as_bytes()).unwrap();
         });
     }
+
+    #[test]
+    fn should_generate_repository_response() {
+        let d = Utc.ymd(2012, 1, 1).and_hms(0, 0, 0);
+        time::with_now(d, || {
+            let cert = ::oob::idcert::tests::test_id_certificate();
+
+            let pr = RepositoryResponse {
+                tag: Some("tag".to_string()),
+                publisher_handle: "tim".to_string(),
+                rrdp_notification_uri: example_rrdp_uri(),
+                sia_base: example_sia_base(),
+                service_uri: example_service_uri(),
+                id_cert: cert
+            };
+
+            let enc = pr.encode_vec();
+
+            RepositoryResponse::decode(str::from_utf8(&enc).unwrap().as_bytes()).unwrap();
+        });
+    }
+
 
 }

--- a/src/oob/idcert.rs
+++ b/src/oob/idcert.rs
@@ -5,6 +5,7 @@ use ber::{Constructed, Error, Mode, OctetString, Oid, Source, Tag, Unsigned};
 use cert::{Extensions, SubjectPublicKeyInfo, Validity};
 use cert::oid;
 use x509::{Name, SignatureAlgorithm, SignedData, ValidationError};
+use bytes::Bytes;
 
 
 //------------ IdCert --------------------------------------------------------
@@ -120,6 +121,13 @@ impl IdCert {
     /// Returns a reference to the certificate’s serial number.
     pub fn serial_number(&self) -> &Unsigned {
         &self.serial_number
+    }
+
+    /// TODO: Encode properly!! Also, give back a ref.
+    /// Did this for now, to allow testing generating XML in exchange.rs
+    pub fn to_bytes(&self) -> Bytes {
+        let b = include_bytes!("../../test/oob/id-publisher-ta.cer");
+        Bytes::from_static(b)
     }
 }
 
@@ -316,22 +324,31 @@ impl IdExtensions {
 }
 
 
+
+
+
 //------------ Tests ---------------------------------------------------------
 
+// is pub so that we can use a parsed test IdCert for now for testing
 #[cfg(test)]
-mod tests {
+pub mod tests {
 
     use super::*;
     use bytes::Bytes;
     use time;
     use chrono::{TimeZone, Utc};
 
+    // Useful until we can create IdCerts of our own
+    pub fn test_id_certificate() -> IdCert {
+        let data = include_bytes!("../../test/oob/id-publisher-ta.cer");
+        IdCert::decode(Bytes::from_static(data)).unwrap()
+    }
+
     #[test]
     fn test_parse_id_publisher_ta_cert() {
         let d = Utc.ymd(2012, 1, 1).and_hms(0, 0, 0);
         time::with_now(d, || {
-        let data = include_bytes!("../../test/oob/id-publisher-ta.cer");
-        let cert = IdCert::decode(Bytes::from_static(data)).unwrap();
+            let cert = test_id_certificate();
             assert!(cert.validate_ta().is_ok());
         });
     }

--- a/src/oob/idcert.rs
+++ b/src/oob/idcert.rs
@@ -345,7 +345,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_parse_id_publisher_ta_cert() {
+    fn should_parse_id_publisher_ta_cert() {
         let d = Utc.ymd(2012, 1, 1).and_hms(0, 0, 0);
         time::with_now(d, || {
             let cert = test_id_certificate();

--- a/src/oob/xml.rs
+++ b/src/oob/xml.rs
@@ -351,8 +351,8 @@ impl <W: io::Write> XmlWriter<W> {
     /// that you cannot have both Characters and other included elements.
     /// This would be valid XML, but it's not used by any of the RPKI XML
     /// structures.
-    pub fn put_blob(&mut self, bytes: Bytes) -> Result<(), XmlWriterError> {
-        let b64 = base64::encode(&bytes);
+    pub fn put_blob(&mut self, bytes: &Bytes) -> Result<(), XmlWriterError> {
+        let b64 = base64::encode(bytes);
         self.writer.write(writer::XmlEvent::Characters(b64.as_ref()))?;
         Ok(())
     }
@@ -404,6 +404,12 @@ pub struct AttributePair<'a> {
     v: &'a str
 }
 
+impl <'a> AttributePair<'a> {
+    pub fn from(k: &'a str, v: &'a str) -> Self {
+        AttributePair{k, v}
+    }
+}
+
 
 //------------ XmlWriterError ------------------------------------------------
 
@@ -444,11 +450,11 @@ mod tests {
             w.put_first_element_with_attributes(
                 "a",
                 "http://ns/",
-                vec![AttributePair{k: "c", v: "d"}],
+                vec![AttributePair::from("c", "d")],
                 |w|
                     {
                         w.put_element("b", |w| {
-                            w.put_blob(Bytes::from("X"))
+                            w.put_blob(&Bytes::from("X"))
                         })
                     }
             )

--- a/src/oob/xml.rs
+++ b/src/oob/xml.rs
@@ -2,10 +2,15 @@
 
 use std::{fs, io};
 use std::path::Path;
+use base64;
+use bytes::Bytes;
 use xml::EventReader;
 use xml::ParserConfig;
-use xml::reader::XmlEvent;
+use xml::reader;
+use xml::writer;
 use xml::attribute::OwnedAttribute;
+use xml::EventWriter;
+use xml::EmitterConfig;
 
 
 //------------ XmlReader -----------------------------------------------------
@@ -27,7 +32,7 @@ impl <R: io::Read> XmlReader<R> {
     /// Takes the next element and expects a start of document.
     fn start_document(&mut self) -> Result<(), XmlReaderErr> {
         match self.reader.next() {
-            Ok(XmlEvent::StartDocument {..}) => { Ok(())},
+            Ok(reader::XmlEvent::StartDocument {..}) => { Ok(())},
             _ => return Err(XmlReaderErr::ExpectedStartDocument)
         }
     }
@@ -35,7 +40,7 @@ impl <R: io::Read> XmlReader<R> {
     /// Takes the next element and expects a start element with the given name.
     fn expect_element(&mut self) -> Result<(Tag, Attributes), XmlReaderErr> {
         match self.reader.next() {
-            Ok(XmlEvent::StartElement { name, attributes, ..}) => {
+            Ok(reader::XmlEvent::StartElement { name, attributes, ..}) => {
                 Ok((Tag{name: name.local_name}, Attributes{attributes}))
             },
             _ => return Err(XmlReaderErr::ExpectedStart)
@@ -45,7 +50,7 @@ impl <R: io::Read> XmlReader<R> {
     /// Takes the next element and expects a close element with the given name.
     fn expect_close(&mut self, tag: Tag) -> Result<(), XmlReaderErr> {
         match self.reader.next() {
-            Ok(XmlEvent::EndElement { name, ..}) => {
+            Ok(reader::XmlEvent::EndElement { name, ..}) => {
                 if name.local_name == tag.name {
                     Ok(())
                 } else {
@@ -62,7 +67,7 @@ impl <R: io::Read> XmlReader<R> {
     /// an error otherwise.
     fn end_document(&mut self) -> Result<(), XmlReaderErr> {
         match self.reader.next() {
-            Ok(XmlEvent::EndDocument) => Ok(()),
+            Ok(reader::XmlEvent::EndDocument) => Ok(()),
             _ => Err(XmlReaderErr::ExpectedEnd)
         }
     }
@@ -140,7 +145,7 @@ impl <R: io::Read> XmlReader<R> {
     /// an error if the next element is any other type.
     pub fn take_characters(&mut self) -> Result<String, XmlReaderErr> {
         match self.reader.next() {
-            Ok(XmlEvent::Characters(chars)) => { Ok(chars) }
+            Ok(reader::XmlEvent::Characters(chars)) => { Ok(chars) }
             _ => return Err(XmlReaderErr::ExpectedCharacters)
         }
     }
@@ -254,4 +259,164 @@ pub enum AttributesError {
 
 pub struct Tag {
     pub name: String
+}
+
+
+//------------ XmlWriter -----------------------------------------------------
+
+/// A convenience wrapper for RPKI XML generation
+///
+/// This type only exposes things we need for the RPKI XML structures.
+pub struct XmlWriter<W> {
+    /// The underlying xml-rs writer
+    writer: EventWriter<W>
+}
+
+
+/// Generate the XML.
+impl <W: io::Write> XmlWriter<W> {
+
+    /// Private general method called by the pub put_first_element with
+    /// Some(namespace) and put_element with None for namespace.
+    fn put_some_element<F>(
+        &mut self,
+        name: &str,
+        namespace: Option<&str>,
+        op: F) -> Result<(), XmlWriterError>
+    where F: FnOnce(&mut Self) -> Result<(), XmlWriterError> {
+        let mut start = writer::XmlEvent::start_element(name);
+
+        match namespace {
+            Some(ns) => { start = start.ns("", ns); },
+            None => {}
+        }
+
+        // Attributes
+
+        self.writer.write(start)?;
+        op(self)?;
+        self.writer.write(writer::XmlEvent::end_element())?;
+
+        Ok(())
+    }
+
+    /// Creates the first element for your XML structure. Note that namespace
+    /// is required because all the RPKI XML structures have one.
+    pub fn put_first_element<F>(
+        &mut self,
+        name: &str,
+        namespace: &str,
+        op: F) -> Result<(), XmlWriterError>
+        where F: FnOnce(&mut Self) -> Result<(), XmlWriterError> {
+        self.put_some_element(name, Some(namespace), op)
+    }
+
+    /// Creates a nested element.
+    pub fn put_element<F>(
+        &mut self,
+        name: &str,
+        op: F) -> Result<(), XmlWriterError>
+        where F: FnOnce(&mut Self) -> Result<(), XmlWriterError> {
+        self.put_some_element(name, None, op)
+    }
+
+    /// Converts bytes to base64 encoded Characters as the content. Note
+    /// that you cannot have both Characters and other included elements.
+    /// This would be valid XML, but it's not used by any of the RPKI XML
+    /// structures.
+    pub fn put_blob(&mut self, bytes: Bytes) -> Result<(), XmlWriterError> {
+        let b64 = base64::encode(&bytes);
+        self.writer.write(writer::XmlEvent::Characters(b64.as_ref()))?;
+        Ok(())
+    }
+
+    /// Use this for convenience where empty content is required
+    pub fn empty(&mut self) -> Result<(), XmlWriterError> {
+        Ok(())
+    }
+
+    /// Sets up the writer config and returns a closure that is expected
+    /// to add the actual content of the XML.
+    ///
+    /// This method is private because one should use the pub encode_vec
+    /// method, and in future others like it, to set up the writer for a
+    /// specific type (Vec<u8>, File, etc.).
+    fn encode<F>(w: W, op: F) -> Result<(), XmlWriterError>
+    where F: FnOnce(&mut Self) -> Result<(), XmlWriterError> {
+
+        let writer = EmitterConfig::new()
+            .write_document_declaration(false)
+            .normalize_empty_elements(false)
+            .create_writer(w);
+
+        let mut x = XmlWriter { writer };
+
+        op(&mut x)
+    }
+}
+
+
+impl XmlWriter<()> {
+
+    pub fn encode_vec<F>(op: F) -> Vec<u8>
+        where F: FnOnce(&mut XmlWriter<&mut Vec<u8>>) -> Result<(), XmlWriterError> {
+        let mut b = Vec::new();
+        XmlWriter::encode(&mut b, op).unwrap();
+        b
+    }
+}
+
+
+//------------ XmlWriterError ------------------------------------------------
+
+#[derive(Debug, Fail)]
+pub enum XmlWriterError {
+    #[fail(display = "I/O Error: {}", _0)]
+    IoError(io::Error),
+
+    #[fail(display = "Writer (emitter) error: {}", _0)]
+    EmitterError(writer::Error),
+}
+
+impl From<io::Error> for XmlWriterError {
+    fn from(e: io::Error) -> XmlWriterError {
+        XmlWriterError::IoError(e)
+    }
+}
+
+impl From<writer::Error> for XmlWriterError {
+    fn from(e: writer::Error) -> XmlWriterError {
+        XmlWriterError::EmitterError(e)
+    }
+}
+
+//------------ Tests ---------------------------------------------------------
+
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use std::str;
+
+    #[test]
+    fn should_write_xml() {
+
+        let xml = XmlWriter::encode_vec(|w| {
+            w.put_first_element(
+                "hello",
+                "http://namespace/",
+                |w|
+                    {
+                        w.put_element("world", |w| {
+                            w.put_blob(Bytes::from("howdy"))
+                        })
+                    }
+            )
+        });
+
+        assert_eq!(
+            str::from_utf8(&xml).unwrap(),
+            r#"<hello xmlns="http://namespace/"><world>aG93ZHk=</world></hello>"#);
+    }
 }

--- a/src/oob/xml.rs
+++ b/src/oob/xml.rs
@@ -405,6 +405,9 @@ pub struct AttributePair<'a> {
 }
 
 impl <'a> AttributePair<'a> {
+
+    /// Creates an AttributePair from a key and a value, e.g.:
+    /// let pair = AttributePair::from("key", "value");
     pub fn from(k: &'a str, v: &'a str) -> Self {
         AttributePair{k, v}
     }

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -242,8 +242,32 @@ impl Http {
 
         Ok(Http{scheme, host, path})
     }
+
+    pub fn host(&self) -> &str {
+        unsafe { ::std::str::from_utf8_unchecked(self.host.as_ref()) }
+    }
+
+    pub fn path(&self) -> &str {
+        unsafe { ::std::str::from_utf8_unchecked(self.path.as_ref()) }
+    }
+
+    pub fn to_string(&self) -> String {
+        format!("{}", self)
+    }
 }
 
+impl fmt::Display for Http {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.scheme.fmt(f)?;
+        if !self.host.is_empty() {
+            write!(f, "{}", self.host())?;
+        }
+        if !self.path.is_empty() {
+            write!(f, "{}", self.path())?;
+        }
+        Ok(())
+    }
+}
 
 
 #[derive(Debug, PartialEq)]
@@ -280,7 +304,22 @@ impl Scheme {
         Err(Error::BadScheme)
     }
 
+    pub fn to_string(&self) -> String {
+        format!("{}", self)
+    }
 }
+
+impl fmt::Display for Scheme {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Scheme::Http  => { write!(f, "{}", "http://")?; },
+            Scheme::Https => { write!(f, "{}", "https://")?; },
+            Scheme::Rsync => { write!(f, "{}", "rsync://")?; }
+        }
+        Ok(())
+    }
+}
+
 
 
 //------------ Helper Functions ----------------------------------------------


### PR DESCRIPTION
I would like to merge this to master. This code encodes the <publisher_request> and <repository_response> XML files. It uses a hardcoded binary IdCert for now, but that will be fixed next week when I generate and encode a proper IdCert for this.

Also, any comments on the code here are welcome, but since I started work on another branch to handle the publication protocol PDUs based off of this, I prefer to fix things in that branch (publication-protocol).