### PR TITLE
Add TAL information to origin information.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpki"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>"]
 description = "A library for validating and creating RPKI data."
 repository = "https://github.com/NLnetLabs/rpki-rs"

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,10 @@ New
 
   The name will be based on the stem of the file name of the TAL file.
 
+* `roa::RouteOriginAttestation`` now has a `status` function that returns
+  a reference to a `RoaStatus` enum with information about the ROA’s
+  status.
+
 Bug Fixes
 
 Dependencies

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,19 @@
 # Change Log
 
-## 0.1.1
+## 0.2.0
 
 Breaking Changes
 
+* `cert::Cert::validate_ta`: new argument for the new `tal::TalInfo` struct
+  containing information about the TAL this trust anchor is based on.
+
 New
+
+* `cert::ResourceCert` now provides information about the trust anchor
+  this certificate is derived from. This can be used to present the trust
+  anchor name in validated output.
+
+  The name will be based on the stem of the file name of the TAL file.
 
 Bug Fixes
 

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -529,8 +529,8 @@ impl ResourceCert {
     }
 
     /// Returns information about the TAL this certificate is based on.
-    pub fn tal(&self) -> &TalInfo {
-        self.tal.as_ref()
+    pub fn tal(&self) -> &Arc<TalInfo> {
+        &self.tal
     }
 }
 

--- a/src/roa.rs
+++ b/src/roa.rs
@@ -339,3 +339,12 @@ pub enum RoaStatus {
     Unknown
 }
 
+impl RoaStatus {
+    pub fn tal(&self) -> Option<&Arc<TalInfo>> {
+        match *self {
+            RoaStatus::Valid { ref tal, .. } => Some(tal),
+            _ => None
+        }
+    }
+}
+


### PR DESCRIPTION
This PR adds a new type `TalInfo` which currently only contains the name of the TAL but may have more information added later. A pointer to it (via an arc) is kept during validation in `ResourceCert` and is ultimately added to `RouteOriginAttestation`s. The latter keep it via a new `RoaStatus` field that is the first step towards the ability to keep invalid ROAs for statistical purposes. 