### PR TITLE
enable nightly for CI/CD and speedups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,16 @@ language: rust
 rust:
   - stable
   - beta
+  - nightly
   - 1.34.0
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true
 before_script:
   - rustup component add clippy
 script:
   - cargo build --verbose --all --all-features
   - cargo clippy --all --all-features -- -D warnings
   - cargo test --verbose --all --all-features
+cache: cargo


### PR DESCRIPTION
bring building modalities in sync with nlnetlabs/routinator#151 by building for nightly while allowing failures and caching cargo