### PR TITLE
Serialization of some X.509 types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,8 @@ license = "BSD-3-Clause"
 base64          = "^0.9"
 bcder           = "^0.3"
 bytes           = "^0.4"
-chrono          = "^0.4"
+chrono          = { version = "^0.4", features = [ "serde" ] }
 derive_more     = "^0.14"
-hex             = "^0.3"
 log             = "^0.4"
 openssl         = { version = "^0.10", optional = true }
 quick-xml       = "^0.14"

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -37,10 +37,12 @@ use crate::resources::{AsBlocks, IpBlocks};
 use crate::tal::TalInfo;
 use crate::uri;
 use crate::x509::{
-    KeyIdentifier, Name, SignedData, Serial, Time, Validity, ValidationError,
+    Name, SignedData, Serial, Time, Validity, ValidationError,
     encode_extension, update_first, update_once
 };
-use crate::crypto::{PublicKey, SignatureAlgorithm, Signer, SigningError};
+use crate::crypto::{
+    KeyIdentifier, PublicKey, SignatureAlgorithm, Signer, SigningError
+};
 use crate::resources::{
     AddressFamily, AsBlocksBuilder, AsResources, AsResourcesBuilder,
     IpBlocksBuilder, IpResources, IpResourcesBuilder

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -325,7 +325,7 @@ impl Cert {
         
         // 4.8.2. Subject Key Identifer. Must be the SHA-1 hash of the octets
         // of the subjectPublicKey.
-        if *self.subject_key_identifier() != 
+        if self.subject_key_identifier() != 
                              self.subject_public_key_info().key_identifier() {
             return Err(ValidationError)
         }
@@ -743,13 +743,13 @@ impl TbsCert {
     /// when the subject public key is set via [`set_subject_public_key`].
     ///
     /// [`set_subject_public_key`]: #method.set_subject_public_key
-    pub fn subject_key_identifier(&self) -> &KeyIdentifier {
-        &self.subject_key_identifier
+    pub fn subject_key_identifier(&self) -> KeyIdentifier {
+        self.subject_key_identifier
     }
 
     /// Returns a reference to the authority key identifier if present.
-    pub fn authority_key_identifier(&self) -> Option<&KeyIdentifier> {
-        self.authority_key_identifier.as_ref()
+    pub fn authority_key_identifier(&self) -> Option<KeyIdentifier> {
+        self.authority_key_identifier
     }
 
     /// Sets the authority key identifier extension.

--- a/src/crl.rs
+++ b/src/crl.rs
@@ -22,9 +22,11 @@ use bcder::encode::PrimitiveContent;
 use bytes::Bytes;
 use serde::{Serialize, Serializer, Deserialize, Deserializer};
 use crate::{oid, uri};
-use crate::crypto::{PublicKey, SignatureAlgorithm, Signer, SigningError};
+use crate::crypto::{
+    KeyIdentifier, PublicKey, SignatureAlgorithm, Signer, SigningError
+};
 use crate::x509::{
-    KeyIdentifier, Name, Serial, SignedData, Time, ValidationError,
+    Name, Serial, SignedData, Time, ValidationError,
     encode_extension, update_once
 };
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -2,7 +2,9 @@
 //!
 
 pub use self::digest::{Digest, DigestAlgorithm};
-pub use self::keys::{PublicKey, PublicKeyFormat, VerificationError};
+pub use self::keys::{
+    KeyIdentifier, PublicKey, PublicKeyFormat, VerificationError
+};
 pub use self::signer::{Signer, SigningError};
 pub use self::signature::{Signature, SignatureAlgorithm};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@ extern crate base64;
 extern crate bytes;
 extern crate chrono;
 #[macro_use] extern crate derive_more;
-extern crate hex;
 #[macro_use] extern crate log;
 #[cfg(feature = "softkeys")] extern crate openssl;
 extern crate quick_xml;
@@ -54,3 +53,4 @@ pub mod uri;
 pub mod x509;
 pub mod xml;
 
+mod util;

--- a/src/sigobj.rs
+++ b/src/sigobj.rs
@@ -189,7 +189,7 @@ impl SignedObject {
         //
         // c. cert is an EE cert with the SubjectKeyIdentifer matching
         //    the sid field of the SignerInfo.
-        if self.sid != *self.cert.subject_key_identifier() {
+        if self.sid != self.cert.subject_key_identifier() {
             return Err(ValidationError)
         }
         Ok(())
@@ -733,7 +733,7 @@ impl SignedObjectBuilder {
             Overclaim::Refuse,
         );
         cert.set_authority_key_identifier(
-            Some(issuer.subject_key_identifier().clone())
+            Some(issuer.subject_key_identifier())
         );
         cert.set_crl_uri(Some(self.crl_uri));
         cert.set_ca_issuer(Some(self.ca_issuer));

--- a/src/sigobj.rs
+++ b/src/sigobj.rs
@@ -8,16 +8,14 @@ use bytes::Bytes;
 use crate::{oid, uri};
 use crate::cert::{Cert, KeyUsage, Overclaim, ResourceCert, TbsCert};
 use crate::crypto::{
-    Digest, DigestAlgorithm, Signature, SignatureAlgorithm, Signer,
-    SigningError
+    Digest, DigestAlgorithm, KeyIdentifier, Signature, SignatureAlgorithm,
+    Signer, SigningError
 };
 use crate::resources::{
     AsBlocksBuilder, AsResources, AsResourcesBuilder, IpBlocksBuilder,
     IpResources, IpResourcesBuilder
 };
-use crate::x509::{
-    KeyIdentifier, Name, Serial, Time, ValidationError, Validity, update_once
-};
+use crate::x509::{Name, Serial, Time, ValidationError, Validity, update_once};
 
 
 //------------ SignedObject --------------------------------------------------

--- a/src/util/hex.rs
+++ b/src/util/hex.rs
@@ -1,0 +1,29 @@
+//! Converting from and to hex strings.
+
+use std::str;
+
+
+/// Encodes a octet sequence as a hex string.
+///
+/// The function uses `dest` as the buffer for encoding which therefore must
+/// be exactly twice the length of `src`. It returns a reference to this
+/// buffer as a `&str`.
+///
+/// # Panics
+///
+/// The function panics if `dest` is shorter than twice the length of `src`.
+pub fn encode<'a>(src: &[u8], dest: &'a mut [u8]) -> &'a str {
+    let dest = &mut dest[..src.len() * 2];
+    for (s, d) in src.iter().zip(dest.chunks_mut(2)) {
+        d[0] = DIGITS[usize::from(s >> 4)];
+        d[1] = DIGITS[usize::from(s & 0x0F)];
+    }
+    unsafe { str::from_utf8_unchecked(dest) }
+}
+
+pub fn encode_u8(ch: u8) -> [u8; 2] {
+    [DIGITS[usize::from(ch >> 4)], DIGITS[usize::from(ch & 0x0F)]]
+}
+
+const DIGITS: &[u8] = b"0123456789ABCDEF";
+

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub mod hex;

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -265,7 +265,7 @@ impl Serial {
         for i in 0..20 {
             step = step.overflowing_shl(8).0 + u16::from(self.0[i]);
             self.0[i] = (step / rhs) as u8;
-            step = step % rhs;
+            step %= rhs;
         }
         step as u8
     }
@@ -274,7 +274,7 @@ impl Serial {
         self == Serial::default()
     }
 
-    fn encode_dec<'a>(mut self, target: &'a mut [u8; 49]) -> &'a str {
+    fn encode_dec(mut self, target: &mut [u8; 49]) -> &str {
         let mut len = 49;
         while !self.is_zero() {
             len -= 1;


### PR DESCRIPTION
This add serialization to `rpki::x509`’s `Serial`, `Time`, and `Validity` types. It also adds it to `KeyIdentifier` but moves it to `rpki::crypto::keys` as well.