### PR TITLE
Fix BER encoding of resources::Prefix.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,9 @@ New
 
 Bug Fixes
 
+* IP address prefixes (`resources::Prefix`) were encoded wrongly if their
+  length was not divisible by 8. ([#55)]
+
 Dependencies
 
 * Update *ring* to 0.14. [(#53)]
@@ -34,6 +37,7 @@ Dependencies
 [(#51)]: https://github.com/NLnetLabs/rpki-rs/pull/51
 [(#53)]: https://github.com/NLnetLabs/rpki-rs/pull/53
 [(#54)]: https://github.com/NLnetLabs/rpki-rs/pull/54
+[(#55)]: https://github.com/NLnetLabs/rpki-rs/pull/55
 
 
 # 0.4.0


### PR DESCRIPTION
Fixes an issue where the number of unused bits was calculated wrongly in the encoding of IP address prefixes.