### PR TITLE
Updated years_from_now to not blow up on leap days

### DIFF
--- a/src/x509.rs
+++ b/src/x509.rs
@@ -542,18 +542,21 @@ impl Time {
         Self::years_from_now(1)
     }
 
+    pub fn next_year_from_date(years: i32, date: DateTime<Utc>) -> Self {
+        let future_now = date + Duration::days(i64::from(365 * years));
+
+        let year = future_now.year();
+        let month = future_now.month();
+        let day = future_now.day();
+        let hour = future_now.hour();
+        let min = future_now.minute();
+        let sec = future_now.second();
+
+        Self::utc(year, month, day, hour, min, sec)
+    }
+
     pub fn years_from_now(years: i32) -> Self {
-        let now = Utc::now();
-
-        let year = now.year();
-        let month = now.month();
-        let day = now.day();
-
-        let hour = now.hour();
-        let min = now.minute();
-        let sec = now.second();
-
-        Self::utc(year + years, month, day, hour, min, sec)
+        Self::next_year_from_date(years, Utc::now())
     }
 
     pub fn utc(
@@ -1100,6 +1103,68 @@ mod test {
         assert_eq!(
             target,
             b"\x02\x04\x00\x81\x02\x03"
+        );
+    }
+
+    #[test]
+    fn next_year() {
+        let now = DateTime::parse_from_rfc3339("2014-10-21T16:39:57-00:00").unwrap();
+        let future = Time::next_year_from_date(1, DateTime::from_utc(now.naive_utc(), Utc));
+
+        assert_eq!(
+            future.year(),
+            2015
+        );
+        assert_eq!(
+            future.month(),
+            10
+        );
+        assert_eq!(
+            future.day(),
+            21
+        );
+        assert_eq!(
+            future.hour(),
+            16
+        );
+        assert_eq!(
+            future.minute(),
+            39
+        );
+        assert_eq!(
+            future.second(),
+            57
+        );
+    }
+
+    #[test]
+    fn next_year_from_leap() {
+        let now = DateTime::parse_from_rfc3339("2020-02-29T16:39:57-00:00").unwrap();
+        let future = Time::next_year_from_date(1, DateTime::from_utc(now.naive_utc(), Utc));
+
+        assert_eq!(
+            future.year(),
+            2021
+        );
+        assert_eq!(
+            future.month(),
+            2
+        );
+        assert_eq!(
+            future.day(),
+            28
+        );
+        assert_eq!(
+            future.hour(),
+            16
+        );
+        assert_eq!(
+            future.minute(),
+            39
+        );
+        assert_eq!(
+            future.second(),
+            57
         );
     }
 }

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -542,21 +542,36 @@ impl Time {
         Self::years_from_now(1)
     }
 
-    pub fn next_year_from_date(years: i32, date: DateTime<Utc>) -> Self {
-        let future_now = date + Duration::days(i64::from(365 * years));
+    /// Adds number of years to the given date.
+    ///
+    /// If the given date happens to be a leap date,
+    /// the resulting date would be normalized to February 28.
+    ///
+    /// This is the case even if the resulting year is also a leap year.
+    pub fn years_from_date(years: i32, date: DateTime<Utc>) -> Self {
 
-        let year = future_now.year();
-        let month = future_now.month();
-        let day = future_now.day();
-        let hour = future_now.hour();
-        let min = future_now.minute();
-        let sec = future_now.second();
+        let year = date.year();
+        let month = date.month();
 
-        Self::utc(year, month, day, hour, min, sec)
+        let day = {
+            if date.day() == 29 && month == 2 { 28 } else { date.day() }
+        };
+
+        let hour = date.hour();
+        let min = date.minute();
+        let sec = date.second();
+
+        Self::utc(year + years, month, day, hour, min, sec)
     }
 
+    /// Adds given years to the current date.
+    ///
+    /// If current date happens to be a leap date,
+    /// the resulting date would be normalized to February 28.
+    ///
+    /// This is the case even if the resulting year is also a leap year.
     pub fn years_from_now(years: i32) -> Self {
-        Self::next_year_from_date(years, Utc::now())
+        Self::years_from_date(years, Utc::now())
     }
 
     pub fn utc(
@@ -1109,7 +1124,7 @@ mod test {
     #[test]
     fn next_year() {
         let now = DateTime::parse_from_rfc3339("2014-10-21T16:39:57-00:00").unwrap();
-        let future = Time::next_year_from_date(1, DateTime::from_utc(now.naive_utc(), Utc));
+        let future = Time::years_from_date(1, DateTime::from_utc(now.naive_utc(), Utc));
 
         assert_eq!(
             future.year(),
@@ -1140,11 +1155,11 @@ mod test {
     #[test]
     fn next_year_from_leap() {
         let now = DateTime::parse_from_rfc3339("2020-02-29T16:39:57-00:00").unwrap();
-        let future = Time::next_year_from_date(1, DateTime::from_utc(now.naive_utc(), Utc));
+        let future = Time::years_from_date(10, DateTime::from_utc(now.naive_utc(), Utc));
 
         assert_eq!(
             future.year(),
-            2021
+            2030
         );
         assert_eq!(
             future.month(),


### PR DESCRIPTION
Tried to start Krill just now and got a panic message:

```
thread 'main' panicked at 'No such local time', ~/.cargo/registry/src/github.com-1ecc6299db9ec823/chrono-0.4.10/src/offset/mod.rs:173:34
stack backtrace:
```

Found the cause to be due to the implementation of `Time::years_from_now` which was simply adding the numeric value of years to the current year. Things go wrong if this is done on a leap day, for example adding 1 year today would give `2021-02-29` which is invalid since 2021 is not a leap year.

This PR seeks to fix that. It calculates the next years by adding 365 days. This means a year from a leap day would now result to February 28.
