### PR TITLE
Deprecate CrlStore.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,10 @@ Breaking
 * The minimum required Rust version is now 1.42. ([#108])
 * The type for RRDP serial numbers has been changed to `u46` from `usize`.
   This affects the various traits in the `rrdp` module. ([#111])
+* `crl::CrlStore` has been deprecated. The new rules for manifest handling
+  have clarified that there must only ever be one CRL for each CA. The
+  `CrlStore` was designed to make it easier to deal with cases where there
+  are multiple CRLs and is therefore not necessary any more. ([#112])
 
 Bug Fixes
 
@@ -39,6 +43,7 @@ Dependencies
 [#109]: https://github.com/NLnetLabs/rpki-rs/pull/109
 [#110]: https://github.com/NLnetLabs/rpki-rs/pull/110
 [#111]: https://github.com/NLnetLabs/rpki-rs/pull/111
+[#112]: https://github.com/NLnetLabs/rpki-rs/pull/112
 
 
 # 0.9.2

--- a/src/crl.rs
+++ b/src/crl.rs
@@ -641,7 +641,7 @@ impl FromStr for CrlEntry {
 ///
 /// Since the new rules for manifest handling clarify that each CA must only
 /// ever have exactly one CRL at any given time, this type is now obsolete.
-#[deprecated(since = "0.10", note = "new manifest rules only allow one CRL")]
+#[deprecated(since = "0.10.0", note = "new manifest rules only allow one CRL")]
 #[allow(deprecated)]
 #[derive(Clone, Debug)]
 pub struct CrlStore {

--- a/src/crl.rs
+++ b/src/crl.rs
@@ -638,6 +638,11 @@ impl FromStr for CrlEntry {
 /// This type allows to store CRLs you have seen in case you may need them
 /// again soon. This is useful when validating the objects issued by a CA as
 /// they likely all refer to the same CRL, so keeping it around makes sense.
+///
+/// Since the new rules for manifest handling clarify that each CA must only
+/// ever have exactly one CRL at any given time, this type is now obsolete.
+#[deprecated(since = "0.10", note = "new manifest rules only allow one CRL")]
+#[allow(deprecated)]
 #[derive(Clone, Debug)]
 pub struct CrlStore {
     /// The CRLs in the store.
@@ -649,6 +654,7 @@ pub struct CrlStore {
     cache_serials: bool,
 }
 
+#[allow(deprecated)]
 impl CrlStore {
     /// Creates a new CRL store.
     pub fn new() -> Self {
@@ -684,6 +690,7 @@ impl CrlStore {
     }
 }
 
+#[allow(deprecated)]
 impl Default for CrlStore {
     fn default() -> Self {
         Self::new()


### PR DESCRIPTION
The new rules for manifest handling have clarified that there must only ever be one CRL for each CA. The `CrlStore` was designed to make it easier to deal with cases where there are multiple CRLs and is therefore not necessary any more.