### PR TITLE
Add decoding and validation of router certificates.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,13 +4,18 @@
 
 Breaking
 
-* The minimum required Rust version is now 1.42. ([#108])
-* The type for RRDP serial numbers has been changed to `u46` from `usize`.
+* `crypto::key::PublicKeyFormat` has been changed into an enum in order to
+  be able to deal with two different possible public key algorithms. It
+  and `crypto::key::PublicKey` also received functions to determine
+  whether the algorithms and keys are allowed in regular RPKI certificates
+  or router certificates. ([#113])
+* The type for RRDP serial numbers has been changed to `u64` from `usize`.
   This affects the various traits in the `rrdp` module. ([#111])
 * `crl::CrlStore` has been deprecated. The new rules for manifest handling
   have clarified that there must only ever be one CRL for each CA. The
   `CrlStore` was designed to make it easier to deal with cases where there
   are multiple CRLs and is therefore not necessary any more. ([#112])
+* The minimum required Rust version is now 1.42. ([#108])
 
 Bug Fixes
 
@@ -21,6 +26,8 @@ Bug Fixes
 
 New
 
+* `cert::Cert` can now decode, inspect, and verify BGPSec router
+  certificates. ([#113])
 * Module `rta` for handling Resource Tagged Assertions.  ([#108])
 * `crypto::DigestAlgorithm::digest_file` allows calculating the digest
   value of an entire file.  ([#108])
@@ -44,6 +51,7 @@ Dependencies
 [#110]: https://github.com/NLnetLabs/rpki-rs/pull/110
 [#111]: https://github.com/NLnetLabs/rpki-rs/pull/111
 [#112]: https://github.com/NLnetLabs/rpki-rs/pull/112
+[#113]: https://github.com/NLnetLabs/rpki-rs/pull/113
 
 
 # 0.9.2

--- a/src/cert/builder.rs
+++ b/src/cert/builder.rs
@@ -473,7 +473,7 @@ mod signer_test {
     #[test]
     fn ta_cert() {
         let mut signer = OpenSslSigner::new();
-        let key = signer.create_key(PublicKeyFormat::default()).unwrap();
+        let key = signer.create_key(PublicKeyFormat::Rsa).unwrap();
         let pubkey = signer.get_key_info(&key).unwrap();
         let uri = uri::Rsync::from_str("rsync://example.com/m/p").unwrap();
 

--- a/src/crl.rs
+++ b/src/crl.rs
@@ -738,7 +738,7 @@ mod signer_test {
     #[test]
     fn build_ta_cert() {
         let mut signer = OpenSslSigner::new();
-        let key = signer.create_key(PublicKeyFormat::default()).unwrap();
+        let key = signer.create_key(PublicKeyFormat::Rsa).unwrap();
         let pubkey = signer.get_key_info(&key).unwrap();
         let crl = TbsCertList::new(
             Default::default(),

--- a/src/crypto/signature.rs
+++ b/src/crypto/signature.rs
@@ -26,7 +26,7 @@ pub struct SignatureAlgorithm(());
 impl SignatureAlgorithm {
     /// Returns the preferred public key format for this algorithm.
     pub fn public_key_format(self) -> PublicKeyFormat {
-        PublicKeyFormat::default()
+        PublicKeyFormat::Rsa
     }
 }
 

--- a/src/crypto/softsigner.rs
+++ b/src/crypto/softsigner.rs
@@ -133,7 +133,12 @@ pub struct KeyId(usize);
 struct KeyPair(PKey<Private>);
 
 impl KeyPair {
-    fn new(_algorithm: PublicKeyFormat) -> Result<Self, io::Error> {
+    fn new(algorithm: PublicKeyFormat) -> Result<Self, io::Error> {
+        if algorithm != PublicKeyFormat::Rsa {
+            return Err(io::Error::new(
+                io::ErrorKind::Other, "invalid algorithm"
+            ));
+        }
         // Issues unwrapping this indicate a bug in the openssl library.
         // So, there is no way to recover.
         let rsa = Rsa::generate(2048)?;
@@ -198,7 +203,7 @@ pub mod tests {
     #[test]
     fn info_sign_delete() {
         let mut s = OpenSslSigner::new();
-        let ki = s.create_key(PublicKeyFormat::default()).unwrap();
+        let ki = s.create_key(PublicKeyFormat::Rsa).unwrap();
         let data = b"foobar";
         let _ = s.get_key_info(&ki).unwrap();
         let _ = s.sign(&ki, SignatureAlgorithm::default(), data).unwrap();

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -387,7 +387,7 @@ mod test {
         use crate::crypto::PublicKeyFormat;
 
         let mut signer = OpenSslSigner::new();
-        let key = signer.create_key(PublicKeyFormat::default()).unwrap();
+        let key = signer.create_key(PublicKeyFormat::Rsa).unwrap();
 
 
         let ca_repo = rsync("rsync://localhost/repo/");

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -534,7 +534,7 @@ mod signer_test {
 
     fn make_test_manifest() -> Manifest {
         let mut signer = OpenSslSigner::new();
-        let key = signer.create_key(PublicKeyFormat::default()).unwrap();
+        let key = signer.create_key(PublicKeyFormat::Rsa).unwrap();
         let pubkey = signer.get_key_info(&key).unwrap();
         let uri = uri::Rsync::from_str("rsync://example.com/m/p").unwrap();
 

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -25,6 +25,16 @@ pub const RSA_ENCRYPTION: ConstOid
 pub const SHA256_WITH_RSA_ENCRYPTION: ConstOid
     = Oid(&[42, 134, 72, 134, 247, 13, 1, 1, 11]);
 
+/// [RFC 5480](https://tools.ietf.org/html/rfc5480) `ecPublicKey`.
+///
+/// Indentifies public keys for ellipic curve cryptography.
+pub const EC_PUBLIC_KEY: ConstOid = Oid(&[42, 134, 72, 206, 61, 2, 1]);
+
+/// [RFC 5480](https://tools.ietf.org/html/rfc5480) `secp256r1`.
+///
+/// Identifies the P-256 curve for elliptic curve cryptography.
+pub const SECP256R1: ConstOid = Oid(&[42, 134, 72, 206, 61, 3, 1, 7]);
+
 
 pub const SIGNED_DATA: Oid<&[u8]>
     = Oid(&[42, 134, 72, 134, 247, 13, 1, 7, 2]);
@@ -65,6 +75,9 @@ pub const CT_RPKI_MANIFEST: ConstOid
     = Oid(&[42, 134, 72, 134, 247, 13, 1, 9, 16, 1, 26]);
 pub const CT_RESOURCE_TAGGED_ATTESTATION: ConstOid
     = Oid(&[42, 134, 72, 134, 247, 13, 1, 9, 16, 1, 36]);
+
+pub const KP_BGPSEC_ROUTER: ConstOid
+    = Oid(&[43, 6, 1, 5, 5, 7, 3, 30]);
 
 pub const PE_AUTHORITY_INFO_ACCESS: Oid<&[u8]>
     = Oid(&[43, 6, 1, 5, 5, 7, 1, 1]);

--- a/src/roa.rs
+++ b/src/roa.rs
@@ -656,7 +656,7 @@ mod signer_test {
 
     fn make_roa() -> Roa {
         let mut signer = OpenSslSigner::new();
-        let key = signer.create_key(PublicKeyFormat::default()).unwrap();
+        let key = signer.create_key(PublicKeyFormat::Rsa).unwrap();
         let pubkey = signer.get_key_info(&key).unwrap();
         let uri = uri::Rsync::from_str("rsync://example.com/m/p").unwrap();
 

--- a/src/sigobj.rs
+++ b/src/sigobj.rs
@@ -975,7 +975,7 @@ mod signer_test {
     #[test]
     fn encode_signed_object() {
         let mut signer = OpenSslSigner::new();
-        let key = signer.create_key(PublicKeyFormat::default()).unwrap();
+        let key = signer.create_key(PublicKeyFormat::Rsa).unwrap();
         let pubkey = signer.get_key_info(&key).unwrap();
         let uri = uri::Rsync::from_str("rsync://example.com/m/p").unwrap();
 


### PR DESCRIPTION
This transforms `PublicKeyFormat` into an enum in order to be able to deal with a second algorithm and modifies `Cert` to be able to decode, inspect, and verify router certificates.