### PR TITLE
Make uri::Rsync a bytes slice.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.43.0, stable, beta, nightly]
+        rust: [1.44.0, stable, beta, nightly]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //! validation where these statements list the AS numbers that are allowed
 //! to originate routes for prefixes.
 
+#![allow(clippy::unknown_clippy_lints)]
 
 pub mod repository;
 pub mod rrdp;

--- a/src/repository/manifest.rs
+++ b/src/repository/manifest.rs
@@ -277,7 +277,7 @@ impl ManifestContent {
         self.iter().map(move |item| {
             let (file, hash) = item.into_pair();
             (
-                base.join(file.as_ref()),
+                base.join(file.as_ref()).unwrap(),
                 ManifestHash::new(hash, alg)
             )
         })

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -839,7 +839,7 @@ pub fn check_uri_ascii<S: AsRef<[u8]>>(slice: S) -> Result<(), Error> {
     }
 }
 
-const fn is_u8_uri_ascii(ch: u8) -> bool {
+fn is_u8_uri_ascii(ch: u8) -> bool {
     matches!(
         ch,
         b'!' | b'$'..=b';' | b'=' | b'A'..=b'Z' | b'_' | b'a'..=b'z' | b'~'


### PR DESCRIPTION
In order to use an rsync URI as a `[u8]` key directly, it needs to be a flat bytes slice instead of the compound object it is today. This PR changes both `uri::Rsync` and `uri::RsyncModule` to be just that.

This requires `uri::Rsync::module` to disappear because it returned a `&RsyncModule` which isn’t possible anymore.