### PR TITLE
Make ManifestHash deal better with possible multiple algorithms.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,12 @@ New
 
 * New module `rtr`, enabled via the feature `rtr` that contains what was
   previously available via the separated `rpki-rtr` crate. ([#120])
+* `ManifestHash` now allows access to its components via the `algorithm`
+  and `as_slice` methods. ([#126])
+* `DigestAlgorithm` instances can now be created for the SHA-256 algorithm
+  and values can be checked whether they in fact represent the SHA-256
+  algorithm. Values now also provide the associated digest length via the
+  new `digest_len` method. ([#126])
 
 Bug Fixes
 
@@ -30,6 +36,7 @@ Other Changes
 [#120]: https://github.com/NLnetLabs/rpki-rs/pull/120
 [#121]: https://github.com/NLnetLabs/rpki-rs/pull/121
 [#124]: https://github.com/NLnetLabs/rpki-rs/pull/124
+[#126]: https://github.com/NLnetLabs/rpki-rs/pull/126
 
 
 ## 0.10.0

--- a/src/repository/crypto/digest.rs
+++ b/src/repository/crypto/digest.rs
@@ -27,6 +27,22 @@ pub use ring::digest::Digest;
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct DigestAlgorithm(());
 
+impl DigestAlgorithm {
+    /// Creates a value representing the SHA-256 algorithm.
+    pub fn sha256() -> Self {
+        DigestAlgorithm(())
+    }
+
+    /// Returns whether the algorithm is in fact SHA-256.
+    pub fn is_sha256(self) -> bool {
+        true
+    }
+
+    /// Returns the digest size in octets for this algorithm.
+    pub fn digest_len(&self) -> usize {
+        32
+    }
+}
 
 /// # Creating Digest Values
 ///

--- a/src/repository/manifest.rs
+++ b/src/repository/manifest.rs
@@ -489,6 +489,16 @@ impl ManifestHash {
             self.algorithm.digest(t.as_ref()).as_ref()
         ).map_err(|_| ValidationError)
     }
+
+    /// Returns the digest algorithm of the hash.
+    pub fn algorithm(&self) -> DigestAlgorithm {
+        self.algorithm
+    }
+
+    /// Returns the hash value as a bytes slice.
+    pub fn as_slice(&self) -> &[u8] {
+        self.hash.as_ref()
+    }
 }
 
 


### PR DESCRIPTION
This PR makes it possible to deal with potentially having multiple digest algorithms in the future. It adds a few functions to `DigestAlgorithm` and `ManifestHash`.