### PR TITLE
Refactor RRDP for fewer allocations.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,10 @@ Breaking
   `uri::Rsync` for both rsync module URIs and URIs below module level.
   The type `uri::RsyncModule` has been dropped. Instead, `uri::Rsync` now
   allows access to the URI’s content as a single bytes slice. ([#124])
+* The `rrdp` module now provides access to object content via a reader
+  rather then decoding it into a vec. In addition, `rrdp::DigestHex` has
+  been renamed to the more clear `rrdp::Hash` and turned into a wrapper
+  around a fixed-size array. ([#129])
 * Upgrade `bytes` and `tokio` to 1.0. ([#121])
 * The minimum required Rust version is now 1.43. ([#121])
 
@@ -39,6 +43,7 @@ Other Changes
 [#124]: https://github.com/NLnetLabs/rpki-rs/pull/124
 [#126]: https://github.com/NLnetLabs/rpki-rs/pull/126
 [#128]: https://github.com/NLnetLabs/rpki-rs/pull/128
+[#129]: https://github.com/NLnetLabs/rpki-rs/pull/129
 
 
 ## 0.10.0

--- a/src/rrdp.rs
+++ b/src/rrdp.rs
@@ -64,7 +64,7 @@ pub struct NotificationFile {
     /// trait.
     ///
     /// Note that after parsing, the list will be in the order as received
-    /// from the server. That is, it not be ordered by serial numbers.
+    /// from the server. That is, it may not be ordered by serial numbers.
     pub deltas: Vec<(u64, UriAndHash)>,
 }
 
@@ -672,6 +672,7 @@ impl<'a> ObjectReader<'a> {
         E: From<ProcessError>,
         F: FnOnce(&mut ObjectReader) -> Result<T, E>
     {
+        // XXX This could probably do with a bit of optimization.
         let data_b64: Vec<_> = content.take_text(reader,  |text| {
             // The text is supposed to be xsd:base64Binary which only allows
             // the base64 characters plus whitespace.

--- a/src/rrdp.rs
+++ b/src/rrdp.rs
@@ -444,14 +444,14 @@ impl str::FromStr for Hash {
         let mut s = s.chars();
         for octet in &mut res {
             let first = s.next().ok_or_else(
-                || ParseHashError::bad_chars()
+                ParseHashError::bad_chars
             )?.to_digit(16).ok_or_else(
-                || ParseHashError::bad_chars()
+                ParseHashError::bad_chars
             )?;
             let second = s.next().ok_or_else(
-                || ParseHashError::bad_chars()
+                ParseHashError::bad_chars
             )?.to_digit(16).ok_or_else(
-                || ParseHashError::bad_chars()
+                ParseHashError::bad_chars
             )?;
             *octet = (first << 4 | second) as u8;
         }

--- a/src/rrdp.rs
+++ b/src/rrdp.rs
@@ -442,18 +442,18 @@ impl str::FromStr for Hash {
         }
         let mut res = [0u8; 32];
         let mut s = s.chars();
-        for pos in 0..32 {
-            let first = s.next().ok_or(
-                ParseHashError::bad_chars()
-            )?.to_digit(16).ok_or(
-                ParseHashError::bad_chars()
+        for octet in &mut res {
+            let first = s.next().ok_or_else(
+                || ParseHashError::bad_chars()
+            )?.to_digit(16).ok_or_else(
+                || ParseHashError::bad_chars()
             )?;
-            let second = s.next().ok_or(
-                ParseHashError::bad_chars()
-            )?.to_digit(16).ok_or(
-                ParseHashError::bad_chars()
+            let second = s.next().ok_or_else(
+                || ParseHashError::bad_chars()
+            )?.to_digit(16).ok_or_else(
+                || ParseHashError::bad_chars()
             )?;
-            res[pos] = (first << 4 | second) as u8;
+            *octet = (first << 4 | second) as u8;
         }
         Ok(Hash(res))
     }

--- a/src/rrdp.rs
+++ b/src/rrdp.rs
@@ -615,6 +615,17 @@ impl From<XmlError> for ProcessError {
     }
 }
 
+impl fmt::Display for ProcessError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ProcessError::Io(ref inner) => inner.fmt(f),
+            ProcessError::Xml(ref inner) => inner.fmt(f)
+        }
+    }
+}
+
+impl error::Error for ProcessError { }
+
 
 //============ Tests =========================================================
 

--- a/src/rrdp.rs
+++ b/src/rrdp.rs
@@ -363,8 +363,8 @@ impl UriAndHash {
         &self.uri
     }
 
-    pub fn hash(&self) -> &Hash {
-        &self.hash
+    pub fn hash(&self) -> Hash {
+        self.hash
     }
 }
 

--- a/src/rrdp.rs
+++ b/src/rrdp.rs
@@ -636,7 +636,7 @@ mod test {
     pub struct Test;
 
     impl ProcessSnapshot for Test {
-        type Err = XmlError;
+        type Err = ProcessError;
 
         fn meta(
             &mut self,
@@ -649,14 +649,14 @@ mod test {
         fn publish(
             &mut self,
             _uri: uri::Rsync,
-            _data: Vec<u8>,
+            _data: &mut ObjectReader,
         ) -> Result<(), Self::Err> {
             Ok(())
         }
     }
 
     impl ProcessDelta for Test {
-        type Err = XmlError;
+        type Err = ProcessError;
 
         fn meta(
             &mut self,
@@ -670,7 +670,7 @@ mod test {
             &mut self,
             _uri: uri::Rsync,
             _hash: Option<Hash>,
-            _data: Vec<u8>,
+            _data: &mut ObjectReader,
         ) -> Result<(), Self::Err> {
             Ok(())
         }

--- a/src/rrdp.rs
+++ b/src/rrdp.rs
@@ -390,6 +390,7 @@ impl UriAndHash {
 /// Since RRDP exclusively uses SHA-256, this is essentially a wrapper around
 /// a 32 byte array.
 #[derive(Clone, Copy, Eq, hash::Hash, PartialEq)]
+#[repr(transparent)]
 pub struct Hash([u8; 32]);
 
 impl Hash {

--- a/src/xml/decode.rs
+++ b/src/xml/decode.rs
@@ -95,7 +95,10 @@ impl<'b, 'n> Element<'b, 'n> {
     /// We don’t support qualified attributes. We will also not check for
     /// those.
     pub fn attributes<F, E>(&self, mut op: F) -> Result<(), E>
-    where F: FnMut(&[u8], AttrValue) -> Result<(), E>, E: From<Error> {
+    where
+        F: FnMut(&[u8], AttrValue) -> Result<(), E>,
+        E: From<Error>
+    {
         for attr in self.start.attributes() {
             let attr = attr.map_err(Into::into)?;
             if attr.key == b"xmlns" {
@@ -154,7 +157,11 @@ impl Content {
         reader: &mut Reader<R>,
         op: F
     ) -> Result<Option<Content>, E>
-    where R: io::BufRead, F: FnOnce(Element) -> Result<(), E>, E: From<Error> {
+    where
+        R: io::BufRead,
+        F: FnOnce(Element) -> Result<(), E>,
+        E: From<Error>
+    {
         if self.empty {
             return Ok(None)
         }
@@ -192,7 +199,11 @@ impl Content {
         reader: &mut Reader<R>,
         op: F
     ) -> Result<T, E>
-    where R: io::BufRead, F: FnOnce(Text) -> Result<T, E>, E: From<Error> {
+    where
+        R: io::BufRead,
+        F: FnOnce(Text) -> Result<T, E>,
+        E: From<Error>
+    {
         if self.empty {
             return Err(Error::Malformed.into())
         }


### PR DESCRIPTION
This PR changes the way the `rrdp` module processes the base64-encoded content of objects from decoding them into a vec to proving a reader that can be used by a consumer in whatever way they like.

In addition, it renames `rrdp::DigestHex` (which is the actual digest, not its hex encoding) into `rrdp::Hash` and changes it into a `Copy` type that wraps a `[u8; 32]` since the hash algorithm is always SHA-256 and there is no way to change that in the protocol.