### PR TITLE
Various API-breaking improvements.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,9 @@ Breaking
   rather then decoding it into a vec. In addition, `rrdp::DigestHex` has
   been renamed to the more clear `rrdp::Hash` and turned into a wrapper
   around a fixed-size array. ([#129])
+* `SignedObject::process` and `Roa::process` now also return the EE
+  certificate on success. ([#XXX])
+* `RoaIpAddress` and `FriendlyRoaIpAddress` are now `Copy`. ([#XXX])
 * Upgrade `bytes` and `tokio` to 1.0. ([#121])
 * The minimum required Rust version is now 1.43. ([#121])
 
@@ -35,6 +38,10 @@ New
 
 Bug Fixes
 
+* `Validity::from_duration` now correctly deals with negative durations.
+  ([#XXX])
+
+
 Other Changes
 
 [#119]: https://github.com/NLnetLabs/rpki-rs/pull/119
@@ -44,6 +51,7 @@ Other Changes
 [#126]: https://github.com/NLnetLabs/rpki-rs/pull/126
 [#128]: https://github.com/NLnetLabs/rpki-rs/pull/128
 [#129]: https://github.com/NLnetLabs/rpki-rs/pull/129
+[#XXX]: https://github.com/NLnetLabs/rpki-rs/pull/XXX
 
 
 ## 0.10.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -19,8 +19,8 @@ Breaking
   been renamed to the more clear `rrdp::Hash` and turned into a wrapper
   around a fixed-size array. ([#129])
 * `SignedObject::process` and `Roa::process` now also return the EE
-  certificate on success. ([#XXX])
-* `RoaIpAddress` and `FriendlyRoaIpAddress` are now `Copy`. ([#XXX])
+  certificate on success. ([#131])
+* `RoaIpAddress` and `FriendlyRoaIpAddress` are now `Copy`. ([#131])
 * Upgrade `bytes` and `tokio` to 1.0. ([#121])
 * The minimum required Rust version is now 1.43. ([#121])
 
@@ -39,7 +39,7 @@ New
 Bug Fixes
 
 * `Validity::from_duration` now correctly deals with negative durations.
-  ([#XXX])
+  ([#131])
 
 
 Other Changes
@@ -51,7 +51,7 @@ Other Changes
 [#126]: https://github.com/NLnetLabs/rpki-rs/pull/126
 [#128]: https://github.com/NLnetLabs/rpki-rs/pull/128
 [#129]: https://github.com/NLnetLabs/rpki-rs/pull/129
-[#XXX]: https://github.com/NLnetLabs/rpki-rs/pull/XXX
+[#131]: https://github.com/NLnetLabs/rpki-rs/pull/131
 
 
 ## 0.10.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //! validation where these statements list the AS numbers that are allowed
 //! to originate routes for prefixes.
 
+#![allow(renamed_and_removed_lints)]
 #![allow(clippy::unknown_clippy_lints)]
 
 pub mod repository;

--- a/src/repository/resources/asres.rs
+++ b/src/repository/resources/asres.rs
@@ -526,7 +526,7 @@ impl<'de> serde::Deserialize<'de> for AsBlocks {
         deserializer: D
     ) -> Result<Self, D::Error> {
         let string = String::deserialize(deserializer)?;
-        Ok(Self::from_str(&string).map_err(serde::de::Error::custom)?)
+        Self::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
 

--- a/src/repository/roa.rs
+++ b/src/repository/roa.rs
@@ -281,7 +281,7 @@ impl<'a> Iterator for RoaIpAddressIter<'a> {
 
 //------------ RoaIpAddress --------------------------------------------------
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct RoaIpAddress {
     prefix: Prefix,
     max_length: Option<u8>
@@ -296,11 +296,11 @@ impl RoaIpAddress {
         RoaIpAddress::new(Prefix::new(addr, len), max_len)
     }
 
-    pub fn prefix(&self) -> Prefix {
+    pub fn prefix(self) -> Prefix {
         self.prefix
     }
 
-    pub fn range(&self) -> (Addr, Addr) {
+    pub fn range(self) -> (Addr, Addr) {
         self.prefix.range()
     }
 }
@@ -347,7 +347,7 @@ impl RoaIpAddress {
 
 //------------ FriendlyRoaIpAddress ------------------------------------------
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct FriendlyRoaIpAddress {
     addr: RoaIpAddress,
     v4: bool
@@ -358,15 +358,15 @@ impl FriendlyRoaIpAddress {
         FriendlyRoaIpAddress { addr, v4 }
     }
 
-    pub fn prefix(&self) -> Prefix {
+    pub fn prefix(self) -> Prefix {
         self.addr.prefix
     }
 
-    pub fn is_v4(&self) -> bool {
+    pub fn is_v4(self) -> bool {
         self.v4
     }
 
-    pub fn address(&self) -> IpAddr {
+    pub fn address(self) -> IpAddr {
         if self.v4 {
             self.addr.prefix.to_v4().into()
         }
@@ -375,11 +375,11 @@ impl FriendlyRoaIpAddress {
         }
     }
 
-    pub fn address_length(&self) -> u8 {
+    pub fn address_length(self) -> u8 {
         self.addr.prefix.addr_len()
     }
 
-    pub fn max_length(&self) -> u8 {
+    pub fn max_length(self) -> u8 {
         self.addr.max_length.unwrap_or_else(||
             self.addr.prefix.addr_len()
         )

--- a/src/repository/roa.rs
+++ b/src/repository/roa.rs
@@ -601,6 +601,7 @@ mod signer_test {
     use crate::repository::crypto::{PublicKeyFormat, Signer};
     use crate::repository::crypto::softsigner::OpenSslSigner;
     use crate::repository::resources::{AsId, Prefix};
+    use crate::repository::tal::TalInfo;
     use crate::repository::x509::Validity;
     use super::*;
 

--- a/src/repository/sigobj.rs
+++ b/src/repository/sigobj.rs
@@ -162,12 +162,12 @@ impl SignedObject {
         issuer: &ResourceCert,
         strict: bool,
         check_crl: F
-    ) -> Result<Bytes, ValidationError>
+    ) -> Result<(ResourceCert, Bytes), ValidationError>
     where F: FnOnce(&Cert) -> Result<(), ValidationError> {
         let res = self.content.clone();
         let cert = self.validate(issuer, strict)?;
         check_crl(cert.as_ref())?;
-        Ok(res.into_bytes())
+        Ok((cert, res.into_bytes()))
     }
 
     /// Validates the signed object.

--- a/src/repository/x509.rs
+++ b/src/repository/x509.rs
@@ -990,10 +990,10 @@ impl Validity {
         let not_before = Time::now();
         let not_after = Time::new(Utc::now() + duration);
         if not_before < not_after {
-            Validity { not_before, not_after }
+            Validity::new(not_before, not_after)
         }
         else {
-            Validity { not_after, not_before }
+            Validity::new(not_after, not_before)
         }
     }
 


### PR DESCRIPTION
This PR collects three changes necessary for  https://github.com/NLnetLabs/routinator/pull/504:

* ROAs and Signed Objects now return their EE certificate in addition to the content upon successful processing.

* `RoaIpAddress` and `FriendlyRoaIpAddress` are now `Copy` (and hence even more friendly).

* `Validity::from_duration` now correctly handles negative durations.