### PR TITLE
Check that a manifest’s thisUpdate is before nextUpdate.

### DIFF
--- a/src/repository/manifest.rs
+++ b/src/repository/manifest.rs
@@ -74,6 +74,22 @@ impl Manifest {
         now: Time
     ) -> Result<(ResourceCert, ManifestContent), ValidationError> {
         let cert = self.signed.validate_at(cert, strict, now)?;
+
+        // RFC 6486, section 4.4:
+        //
+        // |   1. The eContentType in the EncapsulatedContentInfo is
+        // |      id-ad-rpkiManifest (OID 1.2.840.113549.1.9.16.1.26).
+        // |
+        // |   2. The version of the rpkiManifest is 0.
+        //
+        // Both checked during parsing.
+        //
+        // |   3. In the rpkiManifest, thisUpdate precedes nextUpdate.
+
+        if self.content.this_update >= self.content.next_update {
+            return Err(ValidationError)
+        }
+
         Ok((cert, self.content))
     }
 

--- a/src/repository/manifest.rs
+++ b/src/repository/manifest.rs
@@ -580,7 +580,7 @@ mod signer_test {
         let cert = cert.into_cert(&signer, &key).unwrap();
 
         let content = ManifestContent::new(
-            12u64.into(), Time::now(), Time::now(),
+            12u64.into(), Time::now(), Time::next_week(),
             DigestAlgorithm::default(),
             [
                 FileAndHash::new(b"file".as_ref(), b"hash".as_ref()),


### PR DESCRIPTION
This test is mandated by RFC 6486 but had been missing so far.