### PR TITLE
Introduce compat feature and use it to prune prefix lengths in certs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.47.0, stable, beta, nightly]
+        rust: [stable, beta, nightly]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpki"
-version = "0.13.1"
+version = "0.13.2-dev"
 edition = "2018"
 authors = ["The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>"]
 description = "A library for validating and creating RPKI data."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,11 @@ xml = [ "quick-xml" ]
 softkeys = [ "repository", "openssl" ]
 extra-debug = [ "bcder/extra-debug" ]
 
+# Temporary feature that provides compatibility with object written by the
+# library in earlier versions but rejected now. You should probably only
+# enable this in order to read those older objects.
+compat = [ ]
+
 # Dummy features for Windows CI runs where we don’t want to have to deal
 # with OpenSSL
 __windows_ci_all = [ "repository", "rrdp", "rtr", "serde", "extra-debug" ]

--- a/src/repository/resources/ipres.rs
+++ b/src/repository/resources/ipres.rs
@@ -1025,10 +1025,10 @@ impl AddressRange {
     fn parse_content<S: decode::Source>(
         content: &mut decode::Content<S>
     ) -> Result<Self, S::Err> {
-        let mut cons = content.as_constructed()?;
+        let cons = content.as_constructed()?;
         Ok(AddressRange {
-            min: Prefix::take_from(&mut cons)?.min(),
-            max: Prefix::take_from(&mut cons)?.max(),
+            min: Prefix::take_from(cons)?.min(),
+            max: Prefix::take_from(cons)?.max(),
         })
     }
 
@@ -1036,9 +1036,9 @@ impl AddressRange {
         content: &mut decode::Content<S>,
         family: AddressFamily,
     ) -> Result<Self, S::Err> {
-        let mut cons = content.as_constructed()?;
-        let min = Self::check_len(Prefix::take_from(&mut cons)?, family)?;
-        let max = Self::check_len(Prefix::take_from(&mut cons)?, family)?;
+        let cons = content.as_constructed()?;
+        let min = Self::check_len(Prefix::take_from(cons)?, family)?;
+        let max = Self::check_len(Prefix::take_from(cons)?, family)?;
         Ok(AddressRange {
             min: min.min(),
             max: max.max(),
@@ -1445,6 +1445,7 @@ impl Addr {
     }
 
     /// Returns a byte array for the address.
+    #[allow(clippy::transmute_num_to_bytes)]
     pub fn to_bytes(self) -> [u8; 16] {
         unsafe { mem::transmute(self.0.to_be()) }
     }

--- a/src/repository/x509.rs
+++ b/src/repository/x509.rs
@@ -380,6 +380,7 @@ impl Serial {
 
 //--- Default
 
+#[allow(clippy::derivable_impls)]
 impl Default for Serial {
     fn default() -> Self {
         // derive would probably do the same thing, but let’s be explicit


### PR DESCRIPTION
The new `compat` feature will be used to allow reading objects previously created by this library. In this instance, we are using it to allow overly long prefix lengths in certificate resources.