### PR TITLE
Encode prefix where possible

### DIFF
--- a/src/repository/resources/ipres.rs
+++ b/src/repository/resources/ipres.rs
@@ -777,7 +777,12 @@ impl IpBlock {
                 encode::Choice2::One(inner.encode())
             }
             IpBlock::Range(inner) => {
-                encode::Choice2::Two(inner.encode())
+                // If the range is in fact a prefix then this should still
+                // be encoded as a prefix.
+                match inner.into_prefix() {
+                    Ok(prefix) => encode::Choice2::One(prefix.encode()),
+                    Err(range) => encode::Choice2::Two(range.encode())
+                }
             }
         }
     }

--- a/src/repository/resources/set.rs
+++ b/src/repository/resources/set.rs
@@ -46,7 +46,7 @@ impl ResourceSet {
 
     pub fn all() -> ResourceSet {
         let asns = "0-4294967295";
-        let v4 = "0.0.0.0-255.255.255.255";
+        let v4 = "0.0.0.0/0";
         let v6 = "::0/0";
 
         ResourceSet::from_strs(asns, v4, v6).unwrap()


### PR DESCRIPTION
There was an issue where the Krill 0.10.0-rc code TA certificates encoded all IPv4 resources as a range rather than a prefix.