### PR TITLE
Always create a new block when building a resource chain.

### DIFF
--- a/src/repository/resources/chain.rs
+++ b/src/repository/resources/chain.rs
@@ -610,11 +610,11 @@ impl<T: Block> iter::FromIterator<T> for OwnedChain<T> {
                     *res.last_mut().unwrap() = T::new(last_min, block.max())
                 }
                 else {
-                    res.push(block)
+                    res.push(T::new(block.min(), block.max()))
                 }
             }
             else {
-                res.push(block)
+                res.push(T::new(block.min(), block.max()))
             }
         }
         unsafe { Self::from_vec_unchecked(res) }
@@ -670,7 +670,7 @@ fn merge_or_add_block<T: Block>(res: &mut Vec<T>, block: T) {
             return
         }
     }
-    res.push(block)
+    res.push(T::new(block.min(), block.max()))
 }
 
 

--- a/src/repository/resources/chain.rs
+++ b/src/repository/resources/chain.rs
@@ -21,6 +21,9 @@ pub trait Block: Clone {
     type Item: Copy + Eq + Ord;
 
     /// Creates a new block from the minimum and maximum.
+    ///
+    /// This function is also used to convert a block into its canonical
+    /// form.
     fn new(min: Self::Item, max: Self::Item) -> Self;
 
     /// Returns the smallest item that is part of the block.
@@ -610,10 +613,15 @@ impl<T: Block> iter::FromIterator<T> for OwnedChain<T> {
                     *res.last_mut().unwrap() = T::new(last_min, block.max())
                 }
                 else {
+                    // We need to re-create the block from its boundaries so
+                    // it can assume its cannonical form. This is important
+                    // for IP addresses where anything that can be expressed
+                    // as a prefix must be expressed as a prefix.
                     res.push(T::new(block.min(), block.max()))
                 }
             }
             else {
+                // Convert the block into its canonical form.
                 res.push(T::new(block.min(), block.max()))
             }
         }
@@ -670,6 +678,7 @@ fn merge_or_add_block<T: Block>(res: &mut Vec<T>, block: T) {
             return
         }
     }
+    // Convert the block into its canonical form.
     res.push(T::new(block.min(), block.max()))
 }
 

--- a/src/repository/resources/ipres.rs
+++ b/src/repository/resources/ipres.rs
@@ -295,6 +295,12 @@ impl<'a> fmt::Display for IpBlocksForFamily<'a> {
 //------------ IpBlocks ------------------------------------------------------
 
 /// A sequence of address ranges for one address family.
+///
+/// Values of this type are guaranteed to contain a sequence of `IpBlocks`
+/// that fulfills the requirements of RFC 3779. Specifically, the blocks will
+/// not overlap, will not be consecutive (i.e., there’s at least one address
+/// between neighbouring blocks), will be in order, and anything that can be
+/// addressed as a prefix will be.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct IpBlocks(SharedChain<IpBlock>);
 
@@ -595,6 +601,8 @@ impl FromStr for IpBlocks {
 
 impl FromIterator<IpBlock> for IpBlocks {
     fn from_iter<I: IntoIterator<Item = IpBlock>>(iter: I) -> Self {
+        // SharedChain::from_iter does the hard work of ensuring the returned
+        // value is correct.
         Self(SharedChain::from_iter(iter))
     }
 }
@@ -615,6 +623,7 @@ impl IpBlocksBuilder {
     }
 
     pub fn finalize(self) -> IpBlocks {
+        // collect here runs IpBlocks::from_iter to create a correct IpBlocks
         self.0.into_iter().collect()
     }
 }

--- a/src/repository/resources/ipres.rs
+++ b/src/repository/resources/ipres.rs
@@ -1307,13 +1307,19 @@ impl Prefix {
     /// Formats the prefix as an IPv4 prefix.
     pub fn fmt_v4(self, f: &mut fmt::Formatter) -> fmt::Result {
         self.addr.fmt_v4(f)?;
-        write!(f, "/{}", self.len)
+        if self.len != 32 {
+            write!(f, "/{}", self.len)?
+        }
+        Ok(())
     }
 
     /// Formats the prefix as an IPv4 prefix.
     pub fn fmt_v6(self, f: &mut fmt::Formatter) -> fmt::Result {
         self.addr.fmt_v6(f)?;
-        write!(f, "/{}", self.len)
+        if self.len != 128 {
+            write!(f, "/{}", self.len)?
+        }
+        Ok(())
     }
 
     /// Returns the range of addresses covered by this prefix.
@@ -2048,6 +2054,50 @@ mod test {
         let expected_str = "::1, 2001:db8::/32";
         let blocks = IpBlocks::from_str(expected_str).unwrap();
         assert_eq!(expected_str, &blocks.as_v6().to_string())
+    }
+
+    #[test]
+    fn parse_v4range_as_prefix_if_possible() {
+        let range_str = "10.0.0.0-10.0.0.255";
+        let prefix_str = "10.0.0.0/24";
+        let blocks = IpBlocks::from_str(range_str).unwrap();
+        assert_eq!(prefix_str, &blocks.as_v4().to_string())
+    }
+
+    #[test]
+    fn parse_v6range_as_prefix_if_possible() {
+        let range_str = "2001:db8:0:0:0:0:0:0-\
+                         2001:db8:ffff:ffff:ffff:ffff:ffff:ffff";
+        let prefix_str = "2001:db8::/32";
+        let blocks = IpBlocks::from_str(range_str).unwrap();
+        assert_eq!(prefix_str, &blocks.as_v6().to_string())
+    }
+
+    #[test]
+    fn parse_overlapping_v4() {
+        let input = "10.20.0.0, 10.0.0.0/16, 10.30.0.0-10.30.0.255, \
+                     10.0.10.0/24";
+        let output = "10.0.0.0/16, 10.20.0.0, 10.30.0.0/24";
+
+        assert_eq!(
+            IpBlocks::from_str(input).unwrap().as_v4().to_string(),
+            output
+        );
+    }
+
+    #[test]
+    fn parse_overlapping_v6() {
+        let input = "2001:db8:0:20::, \
+                     2001:db8:0:10::/64, \
+                     2001:db8:0:30::-2001:db8:0:30::FF, \
+                     2001:db8:0:10::/72";
+        let output = "2001:db8:0:10::/64, 2001:db8:0:20::, \
+                      2001:db8:0:30::/120"; 
+
+        assert_eq!(
+            IpBlocks::from_str(input).unwrap().as_v6().to_string(),
+            output
+        );
     }
 
     #[test]

--- a/src/repository/resources/ipres.rs
+++ b/src/repository/resources/ipres.rs
@@ -2078,10 +2078,22 @@ mod test {
         let input = "10.20.0.0, 10.0.0.0/16, 10.30.0.0-10.30.0.255, \
                      10.0.10.0/24";
         let output = "10.0.0.0/16, 10.20.0.0, 10.30.0.0/24";
+        let encoded = [
+            0x30, 18,
+                0x03, 3, 0, 10, 0,
+                0x03, 5, 0, 10, 20, 0, 0,
+                0x03, 4, 0, 10, 30, 0
+        ];
+
+        let blocks = IpBlocks::from_str(input).unwrap();
 
         assert_eq!(
-            IpBlocks::from_str(input).unwrap().as_v4().to_string(),
+            blocks.as_v4().to_string(),
             output
+        );
+        assert_eq!(
+            blocks.encode().to_captured(Mode::Der).as_slice(),
+            &encoded
         );
     }
 


### PR DESCRIPTION
This fixes an issue where IP ranges that were also IP prefixes were not converted into prefixes as required by RFC 3779.