### PR TITLE
RTR server: Report the right type of query in Socket::update.

### DIFF
--- a/src/rtr/server.rs
+++ b/src/rtr/server.rs
@@ -402,7 +402,7 @@ impl<Sock: Socket, Source: PayloadSource> Connection<Sock, Source> {
                     self.version(), state, timing
                 ).write(&mut self.sock).await?;
                 self.sock.flush().await?;
-                self.sock.update(state, true);
+                self.sock.update(state, false);
                 Ok(())
             }
             None => {


### PR DESCRIPTION
Currently, the server always sets `reset` to `true`.