### PR TITLE
Switch to stock generic-messages branch of routecore.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,7 @@ openssl         = { version = "0.10.23", optional = true }
 quick-xml       = { version = "0.23.0", optional = true }
 ring            = { version = "0.16.11", optional = true }
 #routecore       = "0.2"
-#routecore       = { version = "0.3.0-dev", git = "https://github.com/NLnetLabs/routecore.git", branch = "generic-messages" }
-routecore       = { version = "0.3.0-dev", git = "https://github.com/NLnetLabs/routecore.git", branch = "extensions-to-generic-messages-used-by-rotonda-runtime" }
+routecore       = { version = "0.3.0-dev", git = "https://github.com/NLnetLabs/routecore.git", branch = "generic-messages" }
 serde           = { version = "1.0.103", optional = true, features = [ "derive" ] }
 serde_json      = { version = "1.0.40", optional = true }
 tokio           = { version = "1.0", optional = true, features = ["io-util",  "net", "rt", "sync", "time"] }


### PR DESCRIPTION
Needed by https://github.com/NLnetLabs/rotonda-runtime/pull/86.