### PR TITLE
Expose `Roa` and `Aspa` inner content

### DIFF
--- a/src/repository/aspa.rs
+++ b/src/repository/aspa.rs
@@ -26,8 +26,8 @@ use super::sigobj::{SignedObject, SignedObjectBuilder};
 //------------ Aspa ----------------------------------------------------------
 #[derive(Clone, Debug)]
 pub struct Aspa {
-    pub signed: SignedObject,
-    pub content: AsProviderAttestation,
+    signed: SignedObject,
+    content: AsProviderAttestation,
 }
 
 impl Aspa {
@@ -70,6 +70,11 @@ impl Aspa {
     /// Returns a reference to the EE certificate of this ROA.
     pub fn cert(&self) -> &Cert {
         self.signed.cert()
+    }
+
+    /// Returns a reference to the content of the ASPA object
+    pub fn content(&self) -> &AsProviderAttestation {
+        &self.content
     }
 }
 

--- a/src/repository/aspa.rs
+++ b/src/repository/aspa.rs
@@ -26,8 +26,8 @@ use super::sigobj::{SignedObject, SignedObjectBuilder};
 //------------ Aspa ----------------------------------------------------------
 #[derive(Clone, Debug)]
 pub struct Aspa {
-    signed: SignedObject,
-    content: AsProviderAttestation,
+    pub signed: SignedObject,
+    pub content: AsProviderAttestation,
 }
 
 impl Aspa {

--- a/src/repository/roa.rs
+++ b/src/repository/roa.rs
@@ -68,7 +68,6 @@ impl Roa {
         self.signed.cert()
     }
 
-
     /// Returns a reference to the content of the ROA object
     pub fn content(&self) -> &RouteOriginAttestation {
         &self.content

--- a/src/repository/roa.rs
+++ b/src/repository/roa.rs
@@ -22,8 +22,8 @@ use super::sigobj::{SignedObject, SignedObjectBuilder};
 
 #[derive(Clone, Debug)]
 pub struct Roa {
-    pub signed: SignedObject,
-    pub content: RouteOriginAttestation,
+    signed: SignedObject,
+    content: RouteOriginAttestation,
 }
 
 impl Roa {
@@ -66,6 +66,12 @@ impl Roa {
     /// Returns a reference to the EE certificate of this ROA.
     pub fn cert(&self) -> &Cert {
         self.signed.cert()
+    }
+
+
+    /// Returns a reference to the content of the ROA object
+    pub fn content(&self) -> &RouteOriginAttestation {
+        &self.content
     }
 }
 

--- a/src/repository/roa.rs
+++ b/src/repository/roa.rs
@@ -22,8 +22,8 @@ use super::sigobj::{SignedObject, SignedObjectBuilder};
 
 #[derive(Clone, Debug)]
 pub struct Roa {
-    signed: SignedObject,
-    content: RouteOriginAttestation,
+    pub signed: SignedObject,
+    pub content: RouteOriginAttestation,
 }
 
 impl Roa {


### PR DESCRIPTION
There is currently no obvious way to consume the content of a `Roa` or a `Aspa` object. This PR adds  a `content(&self)` function to return a reference the the inner content for `Roa` and `Aspa` structs.