### PR TITLE
Support ASPA payload in RTR.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpki"
-version = "0.15.11-dev"
+version = "0.16.0-dev"
 edition = "2018"
 authors = ["The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>"]
 description = "A library for validating and creating RPKI data."

--- a/src/rtr/payload.rs
+++ b/src/rtr/payload.rs
@@ -194,7 +194,7 @@ impl Payload {
     /// Returns the ASPA unit if the value is of the ASPA variant.
     pub fn as_aspa(&self) -> Option<&Aspa> {
         match *self {
-            Payload::Aspa(ref key) => Some(key),
+            Payload::Aspa(ref aspa) => Some(aspa),
             _ => None
         }
     }

--- a/src/rtr/payload.rs
+++ b/src/rtr/payload.rs
@@ -131,7 +131,7 @@ pub struct Aspa {
 }
 
 impl Aspa {
-    /// Crates a new ASPA unt from its components.
+    /// Creates a new ASPA unit from its components.
     pub fn new(
         customer: Asn, afi: Afi, providers: ProviderAsns,
     ) -> Self {
@@ -264,7 +264,7 @@ impl Action {
 
 //------------ Afi -----------------------------------------------------------
 
-/// The RTR represenation of an address family.
+/// The RTR representation of an address family.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Afi(u8);
 

--- a/src/rtr/pdu.rs
+++ b/src/rtr/pdu.rs
@@ -906,7 +906,6 @@ impl Aspa {
                 ))
             }
         };
-        eprintln!("{}", provider_len);
         let mut fixed = AspaFixed { header, .. Default::default() };
         sock.read_exact(&mut fixed.as_mut()[Header::LEN..]).await?;
         if provider_len

--- a/src/rtr/pdu.rs
+++ b/src/rtr/pdu.rs
@@ -964,7 +964,7 @@ impl ProviderAsns {
     pub fn from_asns(iter: impl IntoIterator<Item = Asn>) -> Self {
         let iter = iter.into_iter();
         let mut providers = Vec::with_capacity(iter.size_hint().0);
-        iter.into_iter().for_each(|item| {
+        iter.for_each(|item| {
             providers.extend_from_slice(&item.into_u32().to_be_bytes());
         });
         assert!(providers.len() <= Self::MAX_LEN);

--- a/src/rtr/pdu.rs
+++ b/src/rtr/pdu.rs
@@ -398,7 +398,7 @@ concrete!(Ipv4Prefix);
 
 //------------ Ipv6Prefix ----------------------------------------------------
 
-/// An IPv6 prefix is the payload PDU for route origin authorisation in IPv46.
+/// An IPv6 prefix is the payload PDU for route origin authorisation in IPv6.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 #[repr(packed)]
 #[allow(dead_code)]
@@ -989,7 +989,7 @@ impl ProviderAsns {
     pub fn iter(&self) -> impl Iterator<Item = Asn> + '_ {
         self.0.as_ref().chunks(mem::size_of::<u32>()).map(|chunk| {
             u32::from_be_bytes(
-                TryFrom::try_from(chunk).expect("bad ASPA RDU size")
+                TryFrom::try_from(chunk).expect("bad ASPA PDU size")
             ).into()
         })
     }

--- a/src/rtr/pdu.rs
+++ b/src/rtr/pdu.rs
@@ -612,8 +612,7 @@ impl RouterKey {
                 ))
             }
         };
-        let mut fixed = RouterKeyFixed::default();
-        fixed.header = header;
+        let mut fixed = RouterKeyFixed { header, .. Default::default() };
         sock.read_exact(&mut fixed.as_mut()[Header::LEN..]).await?;
         let key_info = RouterKeyInfo::read(sock, info_len).await?;
         Ok(RouterKey { fixed, key_info })
@@ -908,8 +907,7 @@ impl Aspa {
             }
         };
         eprintln!("{}", provider_len);
-        let mut fixed = AspaFixed::default();
-        fixed.header = header;
+        let mut fixed = AspaFixed { header, .. Default::default() };
         sock.read_exact(&mut fixed.as_mut()[Header::LEN..]).await?;
         if provider_len
             != usize::from(
@@ -1045,7 +1043,7 @@ impl Payload {
                             origin.prefix.prefix_len(),
                             origin.prefix.resolved_max_len(),
                             addr,
-                            origin.asn.into()
+                            origin.asn,
                         ))
                     }
                     IpAddr::V6(addr) => {
@@ -1055,7 +1053,7 @@ impl Payload {
                             origin.prefix.prefix_len(),
                             origin.prefix.resolved_max_len(),
                             addr,
-                            origin.asn.into()
+                            origin.asn,
                         ))
                     }
                 }
@@ -1064,7 +1062,7 @@ impl Payload {
                 Payload::RouterKey(RouterKey::new(
                     version, flags,
                     key.key_identifier.into(),
-                    key.asn.into(),
+                    key.asn,
                     key.key_info.clone()
                 ))
             }
@@ -1196,7 +1194,7 @@ impl Payload {
                             )?,
                             Some(data.max_len())
                         )?,
-                        data.asn().into()
+                        data.asn(),
                     ))
                 }
                 Payload::V6(data) => {
@@ -1207,12 +1205,12 @@ impl Payload {
                             )?,
                             Some(data.max_len())
                         )?,
-                        data.asn().into()
+                        data.asn(),
                     ))
                 }
                 Payload::RouterKey(key) => {
                     Ok(payload::Payload::router_key(
-                        key.key_identifier().into(), key.asn().into(),
+                        key.key_identifier().into(), key.asn(),
                         key.key_info().clone()
                     ))
                 }

--- a/src/rtr/state.rs
+++ b/src/rtr/state.rs
@@ -63,7 +63,7 @@ impl State {
     }
 
     /// Creates a new state value from its components.
-    pub fn from_parts(session: u16, serial: Serial) -> Self {
+    pub const fn from_parts(session: u16, serial: Serial) -> Self {
         State { session, serial }
     }
 
@@ -117,11 +117,11 @@ impl Default for State {
 pub struct Serial(pub u32);
 
 impl Serial {
-    pub fn from_be(value: u32) -> Self {
+    pub const fn from_be(value: u32) -> Self {
         Serial(u32::from_be(value))
     }
 
-    pub fn to_be(self) -> u32 {
+    pub const fn to_be(self) -> u32 {
         self.0.to_be()
     }
 


### PR DESCRIPTION
This PR adds support for protocol version 2 of RTR. This introduces a new PDU type for ASPA payload.

This PR also fixes a bug in the RTR server code that included router key PDUs in the updates even if protocol version 0 was negotiated. (The client code accepts all PDU types in all versions.)

The PR also changes the methods and functions in the `rtr::pdu` module to use the type `Asn` instead of `u32` for ASNs.

 This is a breaking change.