### PR TITLE
Don’t panic on long provider AS sets

### DIFF
--- a/src/rtr/payload.rs
+++ b/src/rtr/payload.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use routecore::addr::MaxLenPrefix;
 use routecore::asn::Asn;
 use routecore::bgpsec::KeyIdentifier;
-use super::pdu::{RouterKeyInfo, ProviderAsns};
+use super::pdu::{ProviderAsns, RouterKeyInfo};
 
 
 //------------ RouteOrigin ---------------------------------------------------
@@ -31,7 +31,7 @@ pub struct RouteOrigin {
     pub prefix: MaxLenPrefix,
 
     /// The autonomous system allowed to announce the prefixes.
-    pub asn: Asn, 
+    pub asn: Asn,
 }
 
 impl RouteOrigin {

--- a/src/rtr/pdu.rs
+++ b/src/rtr/pdu.rs
@@ -962,7 +962,6 @@ impl ProviderAsns {
         let mut providers = Vec::with_capacity(iter.size_hint().0);
         iter.enumerate().try_for_each(|(idx, item)| {
             if idx >= usize::from(u16::MAX) {
-                eprintln!("{}", idx);
                 return Err(ProviderAsnsError(()))
             }
             providers.extend_from_slice(&item.into_u32().to_be_bytes());

--- a/src/rtr/pdu.rs
+++ b/src/rtr/pdu.rs
@@ -955,7 +955,7 @@ impl ProviderAsns {
     ///
     /// Returns an error if there are too many items in the iterator to fit
     /// into an RTR PDU.
-    pub fn from_iter(
+    pub fn try_from_iter(
         iter: impl IntoIterator<Item = Asn>
     ) -> Result<Self, ProviderAsnsError> {
         let iter = iter.into_iter();
@@ -1810,7 +1810,7 @@ mod test {
             Aspa,
             Aspa::new(
                 2, 1, payload::Afi::ipv6(), Asn::from_u32(0x1000f),
-                ProviderAsns::from_iter([
+                ProviderAsns::try_from_iter([
                     Asn::from_u32(0x1000d), Asn::from_u32(0x1000e)
                 ]).unwrap(),
             ),
@@ -1825,19 +1825,19 @@ mod test {
     #[test]
     fn provider_count() {
         assert_eq!(
-            ProviderAsns::from_iter(
+            ProviderAsns::try_from_iter(
                 iter::repeat(Asn::from(0)).take(usize::from(u16::MAX - 1))
             ).unwrap().asn_count(),
             u16::MAX - 1
         );
         assert_eq!(
-            ProviderAsns::from_iter(
+            ProviderAsns::try_from_iter(
                 iter::repeat(Asn::from(0)).take(usize::from(u16::MAX))
             ).unwrap().asn_count(),
             u16::MAX
         );
         assert!(
-            ProviderAsns::from_iter(
+            ProviderAsns::try_from_iter(
                 iter::repeat(Asn::from(0)).take(usize::from(u16::MAX) + 1)
             ).is_err()
         );


### PR DESCRIPTION
This PR changes the previously introduced `rtr::pdu::ProviderAsns::from_iter` type to error out if it is given too many ASNs rather than panicking and renames it to `try_from_iter` to avoid distressing Clippy.