### PR TITLE
Various improvements and changes to support ASPA in the RTR server.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.56.1, stable, beta, nightly]
+        rust: [1.65.0, stable, beta, nightly]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ log             = "0.4.7"
 openssl         = { version = "0.10.23", optional = true }
 quick-xml       = { version = "0.23.0", optional = true }
 ring            = { version = "0.16.11", optional = true }
-routecore       = "0.2"
+routecore       = { git = "https://github.com/NLnetLabs/routecore.git" }
 serde           = { version = "1.0.103", optional = true, features = [ "derive" ] }
 serde_json      = { version = "1.0.40", optional = true }
 tokio           = { version = "1.0", optional = true, features = ["io-util",  "net", "rt", "sync", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rpki"
 version = "0.16.0-dev"
 edition = "2018"
+rust-version = "1.65"
 authors = ["The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>"]
 description = "A library for validating and creating RPKI data."
 documentation = "https://docs.rs/rpki/"

--- a/src/crypto/keys.rs
+++ b/src/crypto/keys.rs
@@ -347,6 +347,8 @@ impl PublicKey {
     }
 
     /// Returns a bytes values of the encoded the *subjectPublicKeyInfo*.
+    ///
+    /// This returns a newly “allocated” bytes object.
     pub fn to_info_bytes(&self) -> Bytes {
         self.encode_ref().to_captured(Mode::Der).into_bytes()
     }

--- a/src/repository/aspa.rs
+++ b/src/repository/aspa.rs
@@ -137,7 +137,7 @@ impl AsProviderAttestation {
         &mut self,
         cert: &ResourceCert
     ) -> Result<(), ValidationError> {
-        if !cert.as_resources().contains(&self.as_blocks()) {
+        if !cert.as_resources().contains_asn(self.customer_as) {
             return Err(VerificationError::new(
                 "customer AS not covered by certificate"
             ).into());
@@ -153,6 +153,10 @@ impl AsProviderAttestation {
         builder.finalize()
     }
 
+    /// Returns the AS resources required by this provider attestation.
+    ///
+    /// The attestation requires resources covering the customer ASN, so
+    /// the method constructs a value containing this ASN.
     pub fn as_resources(&self) -> AsResources {
         AsResources::blocks(self.as_blocks())
     }
@@ -267,6 +271,19 @@ impl ProviderAs {
         self.afi_limit
     }
 
+    pub fn includes_v4(&self) -> bool {
+        match self.afi_limit {
+            Some(limit) => matches!(limit, AddressFamily::Ipv4),
+            None => true
+        }
+    }
+
+    pub fn includes_v6(&self) -> bool {
+        match self.afi_limit {
+            Some(limit) => matches!(limit, AddressFamily::Ipv6),
+            None => true
+        }
+    }
 }
 
 impl ProviderAs {

--- a/src/repository/resources/asres.rs
+++ b/src/repository/resources/asres.rs
@@ -326,6 +326,11 @@ impl AsBlocks {
         self.0.is_empty()
     }
 
+    /// Returns the number of ASNs covered by this value.
+    pub fn asn_count(&self) -> u32 {
+        self.iter().map(|block| block.asn_count()).sum()
+    }
+
     /// Returns an iterator over the ASN blocks.
     pub fn iter(&self) -> impl Iterator<Item = AsBlock> + '_ {
         self.0.iter().copied()
@@ -405,6 +410,11 @@ impl AsBlocks {
 /// # Set operations
 ///
 impl AsBlocks {
+    /// Returns whether this AsBlocks contains an ASN.
+    pub fn contains_asn(&self, asn: Asn) -> bool {
+        self.0.contains_item(asn)
+    }
+
     /// Returns whether this AsBlocks contains the other in its entirety.
     pub fn contains(&self, other: &Self) -> bool {
         other.0.is_encompassed(&self.0)
@@ -632,6 +642,14 @@ impl AsBlock {
         match *self {
             AsBlock::Id(id) => id,
             AsBlock::Range(ref range) => range.max(),
+        }
+    }
+
+    /// Returns the number of ASNs covered by this value.
+    pub fn asn_count(self) -> u32 {
+        match self {
+            AsBlock::Id(_) => 1,
+            AsBlock::Range(range) => range.asn_count()
         }
     }
 
@@ -914,6 +932,11 @@ impl AsRange {
     /// Returns the largest AS number that is still part of this range.
     pub fn max(self) -> Asn {
         self.max
+    }
+
+    /// Returns the number of ASNs covered by this value.
+    pub fn asn_count(self) -> u32 {
+        u32::from(self.max) - u32::from(self.min) + 1
     }
 }
 

--- a/src/repository/resources/asres.rs
+++ b/src/repository/resources/asres.rs
@@ -410,7 +410,7 @@ impl AsBlocks {
 /// # Set operations
 ///
 impl AsBlocks {
-    /// Returns whether this AsBlocks contains an ASN.
+    /// Returns whether this AsBlocks contains a given ASN.
     pub fn contains_asn(&self, asn: Asn) -> bool {
         self.0.contains_item(asn)
     }

--- a/src/repository/resources/chain.rs
+++ b/src/repository/resources/chain.rs
@@ -104,6 +104,19 @@ impl<T: Block> Chain<T> {
         unsafe { mem::transmute::<&[T], _>(&[]) }
     }
 
+    /// Checks whether `self` contains a given item.
+    pub fn contains_item(&self, item: T::Item) -> bool {
+        for block in &self.0 {
+            if block.min() > item {
+                return false
+            }
+            if block.contains(item) {
+                return true
+            }
+        }
+        false
+    }
+
     /// Checks whether `self` is encompassed by `other`.
     ///
     /// The chain `other` needs to be equal to or bigger than `self`.
@@ -878,6 +891,36 @@ mod test {
             ).as_slice(),
             &[(0, 1), (3, 9), (20, 22)][..]
         );
+    }
+
+    #[test]
+    fn contains_item() {
+        let chain = OwnedChain::from([(1,4), (11,18), (23,48)].as_ref());
+        assert!(!chain.contains_item(0));
+
+        assert!(chain.contains_item(1));
+        assert!(chain.contains_item(2));
+        assert!(chain.contains_item(4));
+
+        assert!(!chain.contains_item(5));
+        assert!(!chain.contains_item(8));
+        assert!(!chain.contains_item(10));
+
+        assert!(chain.contains_item(11));
+        assert!(chain.contains_item(14));
+        assert!(chain.contains_item(18));
+
+        assert!(!chain.contains_item(19));
+        assert!(!chain.contains_item(21));
+        assert!(!chain.contains_item(22));
+
+        assert!(chain.contains_item(23));
+        assert!(chain.contains_item(30));
+        assert!(chain.contains_item(48));
+
+        assert!(!chain.contains_item(49));
+        assert!(!chain.contains_item(100));
+        assert!(!chain.contains_item(255));
     }
 
     #[test]

--- a/src/rtr/mod.rs
+++ b/src/rtr/mod.rs
@@ -30,7 +30,7 @@
 #![cfg(feature = "rtr")]
 
 pub use self::client::Client;
-pub use self::payload::{Action, Payload, Timing};
+pub use self::payload::{Action, Payload, PayloadRef, PayloadType, Timing};
 pub use self::server::Server;
 pub use self::state::{State, Serial};
 

--- a/src/rtr/payload.rs
+++ b/src/rtr/payload.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use routecore::addr::MaxLenPrefix;
 use routecore::asn::Asn;
 use routecore::bgpsec::KeyIdentifier;
-use super::pdu::{RouterKeyInfo, ProviderAsns};
+use super::pdu::{ProviderAsns, RouterKeyInfo};
 
 
 //------------ RouteOrigin ---------------------------------------------------
@@ -31,7 +31,7 @@ pub struct RouteOrigin {
     pub prefix: MaxLenPrefix,
 
     /// The autonomous system allowed to announce the prefixes.
-    pub asn: Asn, 
+    pub asn: Asn,
 }
 
 impl RouteOrigin {

--- a/src/rtr/pdu.rs
+++ b/src/rtr/pdu.rs
@@ -951,6 +951,11 @@ impl AsMut<[u8]> for AspaFixed {
 pub struct ProviderAsns(Bytes);
 
 impl ProviderAsns {
+    /// Returns an empty value.
+    pub fn empty() -> Self {
+        Self(Bytes::new())
+    }
+
     /// Creates a new value from an iterator over ASNs.
     ///
     /// Returns an error if there are too many items in the iterator to fit
@@ -1031,9 +1036,9 @@ pub enum Payload {
 
 impl Payload {
     /// Creates a payload PDU for the given payload.
-    pub fn new(version: u8, flags: u8, payload: &payload::Payload) -> Self {
+    pub fn new(version: u8, flags: u8, payload: payload::PayloadRef) -> Self {
         match payload {
-            payload::Payload::Origin(origin) => {
+            payload::PayloadRef::Origin(origin) => {
                 match origin.prefix.addr() {
                     IpAddr::V4(addr) => {
                         Payload::V4(Ipv4Prefix::new(
@@ -1057,7 +1062,7 @@ impl Payload {
                     }
                 }
             }
-            payload::Payload::RouterKey(key) => {
+            payload::PayloadRef::RouterKey(key) => {
                 Payload::RouterKey(RouterKey::new(
                     version, flags,
                     key.key_identifier.into(),
@@ -1065,7 +1070,7 @@ impl Payload {
                     key.key_info.clone()
                 ))
             }
-            payload::Payload::Aspa(aspa) => {
+            payload::PayloadRef::Aspa(aspa) => {
                 Payload::Aspa(Aspa::new(
                     version, flags,
                     aspa.afi, aspa.customer,
@@ -1077,12 +1082,12 @@ impl Payload {
 
     /// Creates a payload PDU if it is supported in the given version.
     pub fn new_if_supported(
-        version: u8, flags: u8, payload: &payload::Payload
+        version: u8, flags: u8, payload: payload::PayloadRef
     ) -> Option<Self> {
         let min_version = match payload {
-            payload::Payload::Origin(_) => 0,
-            payload::Payload::RouterKey(_) => 1,
-            payload::Payload::Aspa(_) => 2,
+            payload::PayloadRef::Origin(_) => 0,
+            payload::PayloadRef::RouterKey(_) => 1,
+            payload::PayloadRef::Aspa(_) => 2,
         };
         if min_version > version {
             None

--- a/src/rtr/pdu.rs
+++ b/src/rtr/pdu.rs
@@ -955,7 +955,7 @@ impl ProviderAsns {
     ///
     /// Returns an error if there are too many items in the iterator to fit
     /// into an RTR PDU.
-    pub fn from_iter(
+    pub fn try_from_iter(
         iter: impl IntoIterator<Item = Asn>
     ) -> Result<Self, ProviderAsnsError> {
         let iter = iter.into_iter();
@@ -1810,7 +1810,7 @@ mod test {
             Aspa,
             Aspa::new(
                 2, 1, payload::Afi::ipv6(), Asn::from_u32(0x1000f),
-                ProviderAsns::from_iter([
+                ProviderAsns::try_from_iter([
                     Asn::from_u32(0x1000d), Asn::from_u32(0x1000e)
                 ]).unwrap(),
             ),
@@ -1825,19 +1825,19 @@ mod test {
     #[test]
     fn provider_count() {
         assert_eq!(
-            ProviderAsns::from_iter(
+            ProviderAsns::try_from_iter(
                 iter::repeat(Asn::from(0)).take(usize::from(u16::MAX - 1))
             ).unwrap().asn_count(),
             u16::MAX - 1
         );
         assert_eq!(
-            ProviderAsns::from_iter(
+            ProviderAsns::try_from_iter(
                 iter::repeat(Asn::from(0)).take(usize::from(u16::MAX))
             ).unwrap().asn_count(),
             u16::MAX
         );
         assert!(
-            ProviderAsns::from_iter(
+            ProviderAsns::try_from_iter(
                 iter::repeat(Asn::from(0)).take(usize::from(u16::MAX) + 1)
             ).is_err()
         );

--- a/src/rtr/server.rs
+++ b/src/rtr/server.rs
@@ -16,7 +16,7 @@ use tokio::sync::broadcast;
 use tokio::task::spawn;
 use tokio_stream::{Stream, StreamExt};
 use super::pdu;
-use super::payload::{Action, Payload, Timing};
+use super::payload::{Action, PayloadRef, Timing};
 use super::state::State;
 
 
@@ -77,13 +77,13 @@ pub trait PayloadSource: Clone + Sync + Send + 'static {
 /// A type providing access to a complete payload set.
 pub trait PayloadSet: Sync + Send + 'static {
     /// Returns the next element in the payload set.
-    fn next(&mut self) -> Option<&Payload>;
+    fn next(&mut self) -> Option<PayloadRef>;
 }
 
 /// A type providing access to a diff between payload sets.
 pub trait PayloadDiff: Sync + Send + 'static {
     /// Returns the next element in the diff.
-    fn next(&mut self) -> Option<(&Payload, Action)>;
+    fn next(&mut self) -> Option<(PayloadRef, Action)>;
 }
 
 


### PR DESCRIPTION
This PR includes a number of improvements and changes, some breaking, to support ASPA in the RTR server.

Most importantly, it introduces a new dedicated type for references to any type of RTR payload, `PayloadRef`, rather than using `&Payload`, so a reference can be generated from a reference to a distinct payload type. The server traits now use this new type to refer to payload.

This is a breaking change.