### PR TITLE
Csr ca repo trailing slash

### DIFF
--- a/src/ca/csr.rs
+++ b/src/ca/csr.rs
@@ -19,6 +19,7 @@
 //! - a signature (to prove possession of the public key)
 //!
 
+use std::borrow::Cow;
 use std::fmt;
 use bcder::{decode, encode, ConstOid};
 use bcder::{BitString, Captured, Mode, OctetString, Oid, Tag};
@@ -183,6 +184,12 @@ impl Csr<(), ()> {
         rpki_notify: Option<&uri::Https>
     ) -> Result<Captured, SigningError<S::Error>> {
         let pub_key = signer.get_key_info(key)?;
+
+        let ca_repository = if ca_repository.path_is_dir() {
+            Cow::Borrowed(ca_repository)
+        } else {
+            Cow::Owned(ca_repository.join(b"/").unwrap())
+        };
 
         let content = Captured::from_values(Mode::Der, encode::sequence((
             0_u32.encode(),

--- a/src/ca/idexchange.rs
+++ b/src/ca/idexchange.rs
@@ -1184,7 +1184,9 @@ impl RepoInfo {
     pub fn ca_repository(&self, name_space: &str) -> uri::Rsync {
         match name_space {
             "" => self.sia_base.clone(),
-            _ => self.sia_base.join(name_space.as_ref()).unwrap(),
+            _ => self.sia_base
+                    .join(format!("{}/", name_space).as_bytes())
+                    .unwrap(),
         }
     }
 

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -222,6 +222,11 @@ impl Rsync {
         &self.as_str()[self.path_start..]
     }
 
+    /// Returns whether the URI's path resolves to a directory.
+    pub fn path_is_dir(&self) -> bool {
+        self.path().is_empty() || self.path().ends_with("/")
+    }
+
     /// Returns the URI’s path as a bytes slice.
     pub fn path_bytes(&self) -> &[u8] {
         &self.bytes[self.path_start..]

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -224,7 +224,7 @@ impl Rsync {
 
     /// Returns whether the URI's path resolves to a directory.
     pub fn path_is_dir(&self) -> bool {
-        self.path().is_empty() || self.path().ends_with("/")
+        self.path().is_empty() || self.path().ends_with('/')
     }
 
     /// Returns the URI’s path as a bytes slice.


### PR DESCRIPTION
This PR enforces a trailing slash for CSRs at two levels. First it ensures that the `ca_repository` ends with a trailing slash. Secondly, it will now inject a trailing slash even if it is missing the ca_repository URI that is submitted when a CSR is created.

The latter may be overkill. Perhaps it should actually return an error instead if the trailing slash is missing, rather than apply a magic fix. But there is currently no convenient way to return a specific error for this.