### PR TITLE
Implement `Arbitrary` for RTR payload types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ log             = "0.4.7"
 openssl         = { version = "0.10.23", optional = true }
 quick-xml       = { version = "0.23.0", optional = true }
 ring            = { version = "0.16.11", optional = true }
-routecore       = { git = "https://github.com/NLnetLabs/routecore.git", branch = "arbitrary" }
+routecore       = { git = "https://github.com/NLnetLabs/routecore.git" }
 serde           = { version = "1.0.103", optional = true, features = [ "derive" ] }
 serde_json      = { version = "1.0.40", optional = true }
 tokio           = { version = "1.0", optional = true, features = ["io-util",  "net", "rt", "sync", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+arbitrary       = { version = "1", optional = true, features = ["derive"] }
 base64          = "0.13.0"
 bcder           = { version = "0.7", optional = true }
 bytes           = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ compat = [ ]
 xml = [ "quick-xml" ]
 
 # Extra features provided.
-arbitrary = ["dep:arbitrary", "routecore/arbitrary"]
+arbitrary = ["dep:arbitrary", "chrono/arbitrary", "routecore/arbitrary"]
 serde-support = ["serde", "routecore/serde"]
 softkeys = [ "openssl" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ log             = "0.4.7"
 openssl         = { version = "0.10.23", optional = true }
 quick-xml       = { version = "0.23.0", optional = true }
 ring            = { version = "0.16.11", optional = true }
-routecore       = { git = "https://github.com/NLnetLabs/routecore.git" }
+routecore       = { git = "https://github.com/NLnetLabs/routecore.git", branch = "arbitrary" }
 serde           = { version = "1.0.103", optional = true, features = [ "derive" ] }
 serde_json      = { version = "1.0.40", optional = true }
 tokio           = { version = "1.0", optional = true, features = ["io-util",  "net", "rt", "sync", "time"] }
@@ -59,6 +59,7 @@ compat = [ ]
 xml = [ "quick-xml" ]
 
 # Extra features provided.
+arbitrary = ["dep:arbitrary", "routecore/arbitrary"]
 serde-support = ["serde", "routecore/serde"]
 softkeys = [ "openssl" ]
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,11 +6,14 @@ Breaking changes
 
 * Changes the type of ASNs as arguments and return types in the `rtr::pdu`
   module to `Asn`. ([#250])
+* Changes the RTR server traits to use a new `PayloadRef` type that allows
+  a user to keep the various payload types separatedly. ([#252])
 
 New
 
 * Adds support for protocol version 2 of RTR. Specifically, adds support
-  for ASPA PDUs and payload. ([#250], [#251])
+  for ASPA PDUs and payload. ([#250], [#251], [#252])
+* Added some useful methods to `AsBlocks`. ([#252])
 
 Bug fixes
 
@@ -21,6 +24,7 @@ Other changes
 
 [#250]: https://github.com/NLnetLabs/rpki-rs/pull/250
 [#251]: https://github.com/NLnetLabs/rpki-rs/pull/251
+[#252]: https://github.com/NLnetLabs/rpki-rs/pull/252
 
 
 ## 0.15.10

--- a/src/repository/tal.rs
+++ b/src/repository/tal.rs
@@ -248,6 +248,7 @@ impl fmt::Display for TalUri {
 //------------ TalInfo -------------------------------------------------------
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TalInfo {
     name: String,
 }

--- a/src/repository/x509.rs
+++ b/src/repository/x509.rs
@@ -294,6 +294,7 @@ impl<'de> serde::Deserialize<'de> for Name {
 //
 //  We encode the serial number in 20 octets left padded.
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Serial([u8; 20]);
 
 impl Serial {
@@ -658,6 +659,7 @@ impl<'a, Alg> PrimitiveContent for SignatureValueContent<'a, Alg> {
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Time(DateTime<Utc>);
 
 impl Time {
@@ -1051,6 +1053,7 @@ impl PrimitiveContent for GeneralizedTime {
 
 #[derive(Clone, Debug, Copy, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Validity {
     not_before: Time,
     not_after: Time,

--- a/src/rtr/payload.rs
+++ b/src/rtr/payload.rs
@@ -26,6 +26,7 @@ use super::pdu::{ProviderAsns, RouterKeyInfo};
 /// The type includes authorizations for both IPv4 and IPv6 prefixes which
 /// are separate payload types in RTR.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct RouteOrigin {
     /// The address prefix to authorize.
     pub prefix: MaxLenPrefix,
@@ -99,6 +100,7 @@ impl hash::Hash for RouteOrigin {
 
 /// A BGPsec router key.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct RouterKey {
     /// The subject key identifier of the router key.
     pub key_identifier: KeyIdentifier,
@@ -124,6 +126,7 @@ impl RouterKey {
 
 /// An ASPA ... unit.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Aspa {
     /// The customer ASN.
     pub customer: Asn,
@@ -159,6 +162,7 @@ impl Aspa {
 
 /// The type of a payload item.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum PayloadType {
     Origin,
     RouterKey,
@@ -170,6 +174,7 @@ pub enum PayloadType {
 
 /// All payload types supported by RTR and this crate.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Payload {
     /// A route origin authorisation.
     Origin(RouteOrigin),
@@ -314,6 +319,7 @@ impl<'a> From<&'a Aspa> for PayloadRef<'a> {
 
 /// What to do with a given payload.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Action {
     /// Announce the payload.
     ///
@@ -360,6 +366,7 @@ impl Action {
 
 /// The RTR representation of an address family.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Afi(u8);
 
 impl Afi {

--- a/src/rtr/payload.rs
+++ b/src/rtr/payload.rs
@@ -318,7 +318,7 @@ impl<'a> From<&'a Aspa> for PayloadRef<'a> {
 //------------ Action --------------------------------------------------------
 
 /// What to do with a given payload.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Action {
     /// Announce the payload.
@@ -366,7 +366,6 @@ impl Action {
 
 /// The RTR representation of an address family.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Afi(u8);
 
 impl Afi {
@@ -403,6 +402,22 @@ impl fmt::Display for Afi {
         else {
             f.write_str("ipv6")
         }
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Afi {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>
+    ) -> arbitrary::Result<Self> {
+        bool::arbitrary(u).map(|val| {
+            if val {
+                Self::ipv4()
+            }
+            else {
+                Self::ipv6()
+            }
+        })
     }
 }
 

--- a/src/rtr/pdu.rs
+++ b/src/rtr/pdu.rs
@@ -771,7 +771,7 @@ impl<'a> arbitrary::Arbitrary<'a> for RouterKeyInfo {
     fn arbitrary(
         u: &mut arbitrary::Unstructured<'a>
     ) -> arbitrary::Result<Self> {
-        let size = usize::arbitrary(u)? % RouterKey::max_key_info_size();
+        let size = usize::arbitrary(u)? % (RouterKey::max_key_info_size() + 1);
         Ok(Self(Bytes::copy_from_slice(u.bytes(size)?)))
     }
 }
@@ -1025,9 +1025,9 @@ impl<'a> arbitrary::Arbitrary<'a> for ProviderAsns {
     fn arbitrary(
         u: &mut arbitrary::Unstructured<'a>
     ) -> arbitrary::Result<Self> {
-        let size = usize::arbitrary(u)? % (
-            usize::from(u16::MAX) * mem::size_of::<Asn>()
-        );
+        let size = (
+            usize::arbitrary(u)? % usize::from(u16::MAX
+        ) * mem::size_of::<Asn>();
         Ok(Self(Bytes::copy_from_slice(u.bytes(size)?)))
     }
 }

--- a/src/rtr/pdu.rs
+++ b/src/rtr/pdu.rs
@@ -1026,7 +1026,7 @@ impl<'a> arbitrary::Arbitrary<'a> for ProviderAsns {
         u: &mut arbitrary::Unstructured<'a>
     ) -> arbitrary::Result<Self> {
         let size = (
-            usize::arbitrary(u)? % usize::from(u16::MAX
+            usize::arbitrary(u)? % usize::from(u16::MAX)
         ) * mem::size_of::<Asn>();
         Ok(Self(Bytes::copy_from_slice(u.bytes(size)?)))
     }

--- a/src/rtr/pdu.rs
+++ b/src/rtr/pdu.rs
@@ -764,6 +764,19 @@ impl fmt::Debug for RouterKeyInfo{
 }
 
 
+//--- Arbitrary
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for RouterKeyInfo {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>
+    ) -> arbitrary::Result<Self> {
+        let size = usize::arbitrary(u)? % RouterKey::max_key_info_size();
+        Ok(Self(Bytes::copy_from_slice(u.bytes(size)?)))
+    }
+}
+
+
 //------------ Aspa ----------------------------------------------------------
 
 /// The PDU for ASPA.
@@ -1004,6 +1017,18 @@ impl ProviderAsns {
         let mut providers = vec![0u8; len];
         sock.read_exact(providers.as_mut()).await?;
         Ok(ProviderAsns(providers.into()))
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for ProviderAsns {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>
+    ) -> arbitrary::Result<Self> {
+        let size = usize::arbitrary(u)? % (
+            usize::from(u16::MAX) * mem::size_of::<Asn>()
+        );
+        Ok(Self(Bytes::copy_from_slice(u.bytes(size)?)))
     }
 }
 

--- a/src/rtr/state.rs
+++ b/src/rtr/state.rs
@@ -30,6 +30,7 @@ use std::time::SystemTime;
 /// [`new`]: #method.new
 /// [`inc`]: #method.inc
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct State {
     session: u16,
     serial: Serial
@@ -114,6 +115,7 @@ impl Default for State {
 ///
 /// [RFC 1982]: https://tools.ietf.org/html/rfc1982
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Serial(pub u32);
 
 impl Serial {

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -947,7 +947,7 @@ mod arbitrary {
 
     impl<'a> Arbitrary<'a> for super::Https {
         fn arbitrary(u: &mut Unstructured) -> arbitrary::Result<Self> {
-            let mut res = String::from("rsync://");
+            let mut res = String::from("https://");
             append_host(&mut res, u)?;
             let path_idx = res.len();
             for _ in 0..(u8::arbitrary(u)? % MAX_SEGMENTS){
@@ -967,7 +967,7 @@ mod arbitrary {
         res: &mut String, u: &mut Unstructured
     ) -> arbitrary::Result<()> {
         // Up to 255 characters of [.0-9A-Za-z-].
-        for _ in 0..u8::arbitrary(u)? {
+        for _ in 1..u8::arbitrary(u)? {
             append_char(res, u)?;
         }
 

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -915,6 +915,96 @@ impl fmt::Display for Error {
 impl error::Error for Error { }
 
 
+//------------ Arbitrary -----------------------------------------------------
+
+#[cfg(feature = "arbitrary")]
+mod arbitrary {
+    use std::fmt::Write;
+    use arbitrary::{Arbitrary, Unstructured};
+
+    const MAX_SEGMENTS: u8 = 20;
+    const MAX_SEGMENT_LEN: u8 = 64;
+
+    impl<'a> Arbitrary<'a> for super::Rsync {
+        fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+            let mut res = String::from("rsync://");
+            append_host(&mut res, u)?;
+            let module_start = res.len() + 1;
+            append_path_segment(&mut res, u)?;
+            let path_start = res.len() + 1;
+            for _ in 0..(u8::arbitrary(u)? % MAX_SEGMENTS){
+                append_path_segment(&mut res, u)?;
+            }
+            if bool::arbitrary(u)? {
+                res.push('/');
+            }
+            Ok(Self {
+                bytes: res.into(),
+                module_start, path_start
+            })
+        }
+    }
+
+    impl<'a> Arbitrary<'a> for super::Https {
+        fn arbitrary(u: &mut Unstructured) -> arbitrary::Result<Self> {
+            let mut res = String::from("rsync://");
+            append_host(&mut res, u)?;
+            let path_idx = res.len();
+            for _ in 0..(u8::arbitrary(u)? % MAX_SEGMENTS){
+                append_path_segment(&mut res, u)?;
+            }
+            if bool::arbitrary(u)? {
+                res.push('/');
+            }
+            Ok(Self {
+                uri: res.into(),
+                path_idx
+            })
+        }
+    }
+
+    fn append_host(
+        res: &mut String, u: &mut Unstructured
+    ) -> arbitrary::Result<()> {
+        // Up to 255 characters of [.0-9A-Za-z-].
+        for _ in 0..u8::arbitrary(u)? {
+            append_char(res, u)?;
+        }
+
+        // Optionally append a port.
+        if bool::arbitrary(u)? {
+            res.push(':');
+            write!(res, "{}", u16::arbitrary(u)?).unwrap();
+        }
+        Ok(())
+    }
+
+    fn append_path_segment(
+        res: &mut String, u: &mut Unstructured
+    ) -> arbitrary::Result<()> {
+        res.push('/');
+        for _ in 1..u8::arbitrary(u)? % MAX_SEGMENT_LEN {
+            append_char(res, u)?;
+        }
+        Ok(())
+    }
+
+    fn append_char(
+        res: &mut String, u: &mut Unstructured
+    ) -> arbitrary::Result<()> {
+        const CHARS: [char; 64] = [
+            '-', '.', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+            'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+            'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+            'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+        ];
+
+        res.push(CHARS[usize::arbitrary(u)? % CHARS.len()]);
+        Ok(())
+    }
+}
+
 
 //------------ Tests ---------------------------------------------------------
 


### PR DESCRIPTION
This PR adds implementations of the _arbitrary_ crate’s `Arbitrary` trait to some of the RTR payload types. This is necessary to support fuzzing.

The dependency on _arbitrary_ and consequently the impls are optional.