### PR TITLE
Prepare for release 0.16.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpki"
-version = "0.16.1-dev"
+version = "0.16.1"
 edition = "2018"
 rust-version = "1.63"
 authors = ["The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## Unreleased next version
+## 0.16.1
 
-Breaking changes
+Released 2023-04-25
 
 New
 
@@ -10,8 +10,6 @@ New
   resource types. ([#255])
 * Added more strict checks to validation of ASPA objects in accordance
   with [draft-ietf-sidrops-aspa-profile12](https://datatracker.ietf.org/doc/draft-ietf-sidrops-aspa-profile/12/). ([#256])
-
-Bug fixes
 
 Other changes
 


### PR DESCRIPTION
New

* Added implementations for the `arbitrary::Arbitrary` trait to ASN and IP resource types. ([#255])
* Added more strict checks to validation of ASPA objects in accordance with [draft-ietf-sidrops-aspa-profile12](https://datatracker.ietf.org/doc/draft-ietf-sidrops-aspa-profile/12/). ([#256])

Other changes

* Downgraded the minimum Rust version to 1.63. ([#257])

[#255]: https://github.com/NLnetLabs/rpki-rs/pull/255
[#256]: https://github.com/NLnetLabs/rpki-rs/pull/256
[#257]: https://github.com/NLnetLabs/rpki-rs/pull/257
