### PR TITLE
Additional methods to check if SLURM filters drop payload.

### DIFF
--- a/src/slurm.rs
+++ b/src/slurm.rs
@@ -515,7 +515,7 @@ pub struct BgpsecAssertion {
 
     /// An optional comment.
     #[serde(skip_serializing_if = "Option::is_none")]
-    comment: Option<String>,
+    pub comment: Option<String>,
 }
 
 impl BgpsecAssertion {


### PR DESCRIPTION
This PR adds the drop check to SLURM’s router key filters and provides type specific check methods for both route origin and router key filters.