### PR TITLE
Drop dependency on routecore.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rpki"
 version = "0.16.2-dev"
-edition = "2018"
+edition = "2021"
 rust-version = "1.63"
 authors = ["The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>"]
 description = "A library for validating and creating RPKI data."
@@ -27,7 +27,6 @@ log             = "0.4.7"
 openssl         = { version = "0.10.23", optional = true }
 quick-xml       = { version = "0.23.0", optional = true }
 ring            = { version = "0.16.11", optional = true }
-routecore       = "0.3.1"
 serde           = { version = "1.0.103", optional = true, features = [ "derive" ] }
 serde_json      = { version = "1.0.40", optional = true }
 tokio           = { version = "1.0", optional = true, features = ["io-util",  "net", "rt", "sync", "time"] }
@@ -45,8 +44,8 @@ default = []
 
 # Main components of the crate.
 ca         = [ "repository", "serde-support", "rrdp" ]
-crypto     = [ "bcder", "ring", "untrusted", "routecore/bcder" ]
-repository = [ "bcder", "crypto", "routecore/bcder" ]
+crypto     = [ "bcder", "ring", "untrusted" ]
+repository = [ "bcder", "crypto" ]
 rrdp       = [ "xml", "ring" ]
 rtr        = [ "futures-util", "tokio", "tokio-stream" ]
 slurm      = [ "rtr", "serde-support", "serde_json" ]
@@ -59,8 +58,8 @@ compat = [ ]
 xml = [ "quick-xml" ]
 
 # Extra features provided.
-arbitrary = ["dep:arbitrary", "chrono/arbitrary", "routecore/arbitrary"]
-serde-support = ["serde", "routecore/serde"]
+arbitrary = ["dep:arbitrary", "chrono/arbitrary"]
+serde-support = ["serde"]
 softkeys = [ "openssl" ]
 
 # Dummy features for Windows CI runs where we don’t want to have to deal

--- a/src/crypto/keys.rs
+++ b/src/crypto/keys.rs
@@ -1,7 +1,8 @@
 //! Types and parameters of keys.
 
-use std::{error, fmt, io};
+use std::{error, fmt, io, str};
 use std::convert::{Infallible, TryFrom};
+use std::str::FromStr;
 use bcder::{decode, encode};
 use bcder::{BitString, Mode, Oid, Tag};
 use bcder::decode::{ContentError, DecodeError, Source};
@@ -13,12 +14,8 @@ use ring::error::Unspecified;
 use ring::signature::VerificationAlgorithm;
 use untrusted::Input;
 use crate::oid;
+use crate::util::hex;
 use super::signature::{RpkiSignatureAlgorithm, Signature, SignatureAlgorithm};
-
-
-//------------ Re-exports ----------------------------------------------------
-
-pub use routecore::bgpsec::KeyIdentifier;
 
 
 //------------ PublicKeyFormat -----------------------------------------------
@@ -413,6 +410,233 @@ impl PrimitiveContent for PublicKeyCn {
 }
 
 
+//------------ KeyIdentifier -------------------------------------------------
+
+/// A key identifier.
+///
+/// This is the SHA-1 hash over the public key’s bits.
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct KeyIdentifier([u8; 20]);
+
+impl KeyIdentifier {
+    /// Returns an octet slice of the key identifer’s value.
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+
+    /// Returns a octet array with the hex representation of the identifier.
+    pub fn into_hex(self) -> [u8; 40] {
+        let mut res = [0u8; 40];
+        hex::encode(self.as_slice(), &mut res);
+        res
+    }
+}
+
+#[cfg(feature = "bcder")]
+impl KeyIdentifier {
+    /// Takes an encoded key identifier from a constructed value.
+    ///
+    /// ```text
+    /// KeyIdentifier ::= OCTET STRING
+    /// ```
+    ///
+    /// The content of the octet string needs to be a SHA-1 hash, so it must
+    /// be exactly 20 octets long.
+    pub fn take_from<S: Source>(
+        cons: &mut decode::Constructed<S>
+    ) -> Result<Self, DecodeError<S::Error>> {
+        cons.take_value_if(bcder::Tag::OCTET_STRING, Self::from_content)
+    }
+
+    pub fn take_opt_from<S: Source>(
+        cons: &mut decode::Constructed<S>
+    ) -> Result<Option<Self>, DecodeError<S::Error>> {
+        cons.take_opt_value_if(bcder::Tag::OCTET_STRING, Self::from_content)
+    }
+
+    /// Parses an encoded key identifer from encoded content.
+    pub fn from_content<S: Source>(
+        content: &mut decode::Content<S>
+    ) -> Result<Self, DecodeError<S::Error>> {
+        let octets = bcder::OctetString::from_content(content)?;
+        if let Some(slice) = octets.as_slice() {
+            Self::try_from(slice).map_err(|_| {
+                content.content_err("invalid key identifier")
+            })
+        }
+        else if octets.len() != 20 {
+            Err(content.content_err("invalid key identifier"))
+        }
+        else {
+            let mut res = KeyIdentifier(Default::default());
+            let mut pos = 0;
+            for slice in &octets {
+                let end = pos + slice.len();
+                res.0[pos .. end].copy_from_slice(slice);
+                pos = end;
+            }
+            Ok(res)
+        }
+    }
+
+    /// Skips over an encoded key indentifier.
+    pub fn skip_opt_in<S: Source>(
+        cons: &mut decode::Constructed<S>
+    ) -> Result<Option<()>, DecodeError<S::Error>> {
+        cons.take_opt_value_if(bcder::Tag::OCTET_STRING, |cons| {
+            Self::from_content(cons)?;
+            Ok(())
+        })
+    }
+}
+
+
+//--- From, TryFrom and FromStr
+
+impl From<[u8; 20]> for KeyIdentifier {
+    fn from(src: [u8; 20]) -> Self {
+        KeyIdentifier(src)
+    }
+}
+
+impl From<KeyIdentifier> for [u8; 20] {
+    fn from(src: KeyIdentifier) -> Self {
+        src.0
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for KeyIdentifier {
+    type Error = KeyIdentifierSliceError;
+
+    fn try_from(value: &'a [u8]) -> Result<Self, Self::Error> {
+        value.try_into()
+            .map(KeyIdentifier)
+            .map_err(|_| KeyIdentifierSliceError)
+    }
+}
+
+impl FromStr for KeyIdentifier {
+    type Err = ParseKeyIdentifierError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.len() != 40 || !value.is_ascii() {
+            return Err(ParseKeyIdentifierError)
+        }
+        let mut res = KeyIdentifier(Default::default());
+        for (pos, ch) in value.as_bytes().chunks(2).enumerate() {
+            let ch = unsafe { str::from_utf8_unchecked(ch) };
+            res.0[pos] = u8::from_str_radix(ch, 16)
+                            .map_err(|_| ParseKeyIdentifierError)?;
+        }
+        Ok(res)
+    }
+}
+
+
+//--- AsRef
+
+impl AsRef<[u8]> for KeyIdentifier {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+
+//--- PartialEq
+
+impl<T: AsRef<[u8]>> PartialEq<T> for KeyIdentifier {
+    fn eq(&self, other: &T) -> bool {
+        self.0.as_ref().eq(other.as_ref())
+    }
+}
+
+
+//--- Display and Debug
+
+impl fmt::Display for KeyIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut buf = [0u8; 40];
+        write!(f, "{}", hex::encode(self.as_slice(), &mut buf))
+    }
+}
+
+impl fmt::Debug for KeyIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "KeyIdentifier({})", self)
+    }
+}
+
+
+//--- PrimitiveContent
+
+#[cfg(feature = "bcder")]
+impl bcder::encode::PrimitiveContent for KeyIdentifier {
+    const TAG: bcder::Tag = bcder::Tag::OCTET_STRING;
+
+    fn encoded_len(&self, _mode: bcder::Mode) -> usize {
+        20
+    }
+
+    fn write_encoded<W: std::io::Write>(
+        &self,
+        _mode: bcder::Mode,
+        target: &mut W
+    ) -> Result<(), std::io::Error> {
+        target.write_all(&self.0)
+    }
+}
+
+
+//--- Deserialize and Serialize
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for KeyIdentifier {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S
+    ) -> Result<S::Ok, S::Error> {
+        let mut buf = [0u8; 40];
+        hex::encode(self.as_slice(), &mut buf).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for KeyIdentifier {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D
+    ) -> Result<Self, D::Error> {
+        struct KeyIdentifierVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for KeyIdentifierVisitor {
+            type Value = KeyIdentifier;
+
+            fn expecting(
+                &self, formatter: &mut fmt::Formatter
+            ) -> fmt::Result {
+                write!(formatter,
+                    "a string containing a key identifier as hex digits"
+                )
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where E: serde::de::Error {
+                KeyIdentifier::from_str(s).map_err(serde::de::Error::custom)
+            }
+
+            fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
+            where E: serde::de::Error {
+                KeyIdentifier::from_str(&s).map_err(serde::de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_str(KeyIdentifierVisitor)
+    }
+}
+
+
+//============ Errors ========================================================
+
 //------------ SignatureVerificationError ------------------------------------
 
 /// An error happened while verifying a signature.
@@ -440,6 +664,35 @@ impl fmt::Display for SignatureVerificationError {
 }
 
 impl error::Error for SignatureVerificationError { }
+
+//------------ ParseKeyIdentifierError ---------------------------------------
+
+/// Creating a prefix has failed.
+#[derive(Clone, Debug)]
+pub struct ParseKeyIdentifierError;
+
+impl fmt::Display for ParseKeyIdentifierError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("invalid key identifier")
+    }
+}
+
+impl error::Error for ParseKeyIdentifierError { }
+
+
+//------------ KeyIdentifierSliceError ----------------------------------
+
+/// Creating a prefix has failed.
+#[derive(Clone, Debug)]
+pub struct KeyIdentifierSliceError;
+
+impl fmt::Display for KeyIdentifierSliceError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("invalid slice for key identifier")
+    }
+}
+
+impl error::Error for KeyIdentifierSliceError { }
 
 
 //============ Tests =========================================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,9 +35,12 @@ pub mod ca;
 pub mod crypto;
 pub mod oid;
 pub mod repository;
+pub mod resources;
 pub mod rrdp;
 pub mod rtr;
 pub mod slurm;
 pub mod uri;
 pub mod xml;
+
+mod util;
 

--- a/src/repository/resources/asres.rs
+++ b/src/repository/resources/asres.rs
@@ -21,7 +21,7 @@ use bcder::{decode, encode};
 use bcder::Tag;
 use bcder::decode::{ContentError, DecodeError};
 use bcder::encode::{PrimitiveContent, Nothing};
-use routecore::asn::ParseAsnError;
+use crate::resources::asn::ParseAsnError;
 use super::super::cert::Overclaim;
 use super::super::x509::encode_extension;
 use super::super::error::VerificationError;
@@ -31,7 +31,7 @@ use super::choice::{InheritedResources, ResourcesChoice};
 
 //------------ Re-exports ----------------------------------------------------
 
-pub use routecore::asn::Asn;
+pub use crate::resources::asn::Asn;
 
 
 //------------ AsResources ---------------------------------------------------

--- a/src/repository/resources/set.rs
+++ b/src/repository/resources/set.rs
@@ -5,14 +5,13 @@ use std::str::FromStr;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use routecore::asn::Asn;
-
 use crate::repository::resources::{AsResources, IpResources};
 use crate::repository::Cert;
 use crate::repository::{
     resources::{AsBlock, AsBlocks, AsBlocksBuilder, Ipv4Blocks, Ipv6Blocks},
     roa::RoaIpAddress,
 };
+use crate::resources::asn::Asn;
 
 //------------ ResourceSet ---------------------------------------------------
 

--- a/src/repository/roa.rs
+++ b/src/repository/roa.rs
@@ -140,7 +140,7 @@ impl RouteOriginAttestation {
     pub fn iter_origins(
         &self
     ) -> impl Iterator<Item = crate::rtr::payload::RouteOrigin> + '_ {
-        use routecore::addr::{MaxLenPrefix, Prefix as PayloadPrefix};
+        use crate::resources::addr::{MaxLenPrefix, Prefix as PayloadPrefix};
         use crate::rtr::payload::RouteOrigin;
 
         self.v4_addrs.iter().filter_map(move |addr| {

--- a/src/resources/addr.rs
+++ b/src/resources/addr.rs
@@ -1,0 +1,1386 @@
+//! IP address resources.
+
+use std::{error, fmt};
+use std::cmp::Ordering;
+use std::net::{AddrParseError, IpAddr, Ipv4Addr, Ipv6Addr};
+use std::num::ParseIntError;
+use std::str::FromStr;
+
+
+//------------ Bits ----------------------------------------------------------
+
+/// The value of an IP address.
+///
+/// This private type holds the content of an IP address. It is big enough to
+/// hold either an IPv4 and IPv6 address as it keeps the address internally
+/// as a 128 bit unsigned integer. IPv6 addresses are kept in all bits in host
+/// byte order while IPv4 addresses are kept in the upper four bytes and are
+/// right-padded with zero bits. This makes it possible to count prefix
+/// lengths the same way for both addresses, i.e., starting from the top of
+/// the raw integer.
+///
+/// There is no way of distinguishing between IPv4 and IPv6 from just a value
+/// of this type. This information needs to be carried separately.
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+struct Bits(u128);
+
+impl Bits {
+    /// Creates a new address from 128 raw bits in host byte order.
+    pub fn new(bits: u128) -> Self {
+        Bits(bits)
+    }
+
+    /// Creates a new address value for an IPv4 address.
+    pub fn from_v4(addr: Ipv4Addr) -> Self {
+        Self::new(u128::from(u32::from(addr)) << 96)
+    }
+
+    /// Creates a new address value for an IPv6 address.
+    pub fn from_v6(addr: Ipv6Addr) -> Self {
+        Self::new(u128::from(addr))
+    }
+
+    /// Returns the raw bits of the underlying integer.
+    pub fn into_int(self) -> u128 {
+        self.0
+    }
+
+    /// Converts the address value into an IPv4 address.
+    ///
+    /// The methods disregards the lower twelve bytes of the value.
+    pub fn into_v4(self) -> Ipv4Addr {
+        ((self.0 >> 96) as u32).into()
+    }
+
+    /// Converts the address value into an IPv6 address.
+    pub fn into_v6(self) -> Ipv6Addr {
+        self.0.into()
+    }
+
+    /// Checks whether the host portion of the bits used in a prefix is zero.
+    fn is_host_zero(self, len: u8) -> bool {
+        self.0.trailing_zeros() >= 128u32.saturating_sub(len.into())
+    }
+
+    /// Clears the bits in the host portion of a prefix.
+    fn clear_host(self, len: u8) -> Self {
+        if len == 0 {
+            Bits(0)
+        }
+        else {
+            Bits(self.0 & (u128::MAX << (128u8.saturating_sub(len))))
+        }
+    }
+
+    /// Returns a value with all but the first `prefix_len` bits set.
+    ///
+    /// The first `prefix_len` bits are retained. Thus, the returned address
+    /// is the largest address in a prefix of this length.
+    fn into_max(self, prefix_len: u8) -> Self {
+        if prefix_len >= 128 {
+            self
+        }
+        else {
+            Self(self.0 | (u128::MAX >> prefix_len as usize))
+        }
+    }
+}
+
+
+//--- From
+
+impl From<u128> for Bits {
+    fn from(addr: u128) -> Self {
+        Self::new(addr)
+    }
+}
+
+impl From<Ipv4Addr> for Bits {
+    fn from(addr: Ipv4Addr) -> Self {
+        Self::from_v4(addr)
+    }
+}
+
+impl From<Ipv6Addr> for Bits {
+    fn from(addr: Ipv6Addr) -> Self {
+        Self::from_v6(addr)
+    }
+}
+
+impl From<IpAddr> for Bits {
+    fn from(addr: IpAddr) -> Self {
+        match addr {
+            IpAddr::V4(addr) => Self::from(addr),
+            IpAddr::V6(addr) => Self::from(addr)
+        }
+    }
+}
+
+impl From<Bits> for u128 {
+    fn from(addr: Bits) -> u128 {
+        addr.into_int()
+    }
+}
+
+impl From<Bits> for Ipv4Addr {
+    fn from(addr: Bits) -> Ipv4Addr {
+        addr.into_v4()
+    }
+}
+
+impl From<Bits> for Ipv6Addr {
+    fn from(addr: Bits) -> Ipv6Addr {
+        addr.into_v6()
+    }
+}
+
+
+//--- Debug
+
+impl fmt::Debug for Bits {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("Bits")
+        .field(&format_args!("{}", self.into_v6()))
+        .finish()
+    }
+}
+
+
+//------------ FamilyAndLen --------------------------------------------------
+
+/// The address family and prefix length stored in a single byte.
+///
+/// This private types wraps a `u8` and uses it to store both the address
+/// family – i.e., whether this is an IPv4 or IPv6 prefix –, and the prefix
+/// length.
+///
+/// The encoding is as follows: Values up to 32 represent IPv4 prefixes with
+/// the value as their prefix length. If the left-most bit is set, the value
+/// is a IPv6 prefix with the length encoded by flipping all the bits. The
+/// value of 64 stands in for an IPv6 prefix with length 128.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct FamilyAndLen(u8);
+
+impl FamilyAndLen {
+    /// Creates a value for an IPv4 prefix.
+    pub fn new_v4(len: u8) -> Result<Self, PrefixError> {
+        if len > 32 {
+            Err(PrefixError::LenOverflow)
+        }
+        else {
+            Ok(Self(len))
+        }
+    }
+
+    /// Creates a value for an IPv6 prefix.
+    pub fn new_v6(len: u8) -> Result<Self, PrefixError> {
+        match len.cmp(&128) {
+            Ordering::Greater => Err(PrefixError::LenOverflow),
+            Ordering::Equal => Ok(Self(0x40)),
+            Ordering::Less => Ok(Self(len ^ 0xFF))
+        }
+    }
+
+    /// Returns whether this a IPv4 prefix.
+    pub fn is_v4(self) -> bool {
+        self.0 & 0xc0 == 0
+    }
+
+    /// Returns whether this a IPv6 prefix.
+    pub fn is_v6(self) -> bool {
+        self.0 & 0xc0 != 0
+    }
+
+    /// Returns the prefix length.
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(self) -> u8 {
+        match self.0 & 0xc0 {
+            0x00 => self.0,
+            0x40 => 128,
+            _ => self.0 ^ 0xFF
+        }
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for FamilyAndLen {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>
+    ) -> arbitrary::Result<Self> {
+        if bool::arbitrary(u)? {
+            Ok(Self(u8::arbitrary(u)? % 33))
+        }
+        else {
+            match u8::arbitrary(u)? % 129 {
+                128 => Ok(Self(0x40)),
+                val => Ok(Self(val ^ 0xFF))
+            }
+        }
+    }
+}
+
+
+//------------ Prefix --------------------------------------------------------
+
+/// An IP address prefix: an IP address and a prefix length.
+///
+/// # Ordering
+///
+/// Prefixes are ordered in the following way:
+/// - IPv4 comes before IPv6
+/// - More-specifics come before less-specifics
+/// - Other than that, prefixes are sorted numerically from low to high
+///
+/// The rationale behind this ordering is that in most use cases processing a
+/// more-specific before any less-specific is more efficient (i.e. longest
+/// prefix matching in routing/forwarding)) or preventing unwanted
+/// intermediate stage (i.e. ROAs/VRPs for less-specifics making
+/// not-yet-processed more-specifics Invalid).
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct Prefix {
+    /// The address family and prefix length all in one.
+    family_and_len: FamilyAndLen,
+
+    /// The actual bits of the prefix.
+    bits: Bits,
+}
+
+impl Prefix {
+    /// Creates a new prefix from an address and a length.
+    ///
+    /// The function returns an error if `len` is too large for the address
+    /// family of `addr`.
+    ///
+    /// Use `saturating_new` if you want the prefix length to be capped
+    /// instead.
+    pub fn new(addr: IpAddr, len: u8) -> Result<Self, PrefixError> {
+        match addr {
+            IpAddr::V4(addr) => Self::new_v4(addr, len),
+            IpAddr::V6(addr) => Self::new_v6(addr, len),
+        }
+    }
+
+    /// Creates a new prefix from an IPv4 address and a prefix length.
+    ///
+    /// The function returns an error if `len` is greater than 32.
+    ///
+    /// Use `saturating_new_v4` if you want the prefix length to be capped
+    /// instead.
+    pub fn new_v4(addr: Ipv4Addr, len: u8) -> Result<Self, PrefixError> {
+        let family_and_len = FamilyAndLen::new_v4(len)?;
+
+        // Check that host bits are zero.
+        let bits = Bits::from_v4(addr);
+        if !bits.is_host_zero(len) {
+            return Err(PrefixError::NonZeroHost)
+        }
+
+        Ok(Prefix { family_and_len, bits })
+    }
+
+    /// Creates a new prefix from an IPv6 adddress and a prefix length.
+    ///
+    /// The function returns an error if `len` is greater than 128.
+    ///
+    /// Use `saturating_new_v6` if you want the prefix length to be capped
+    /// instead.
+    pub fn new_v6(addr: Ipv6Addr, len: u8) -> Result<Self, PrefixError> {
+        let family_and_len = FamilyAndLen::new_v6(len)?;
+
+        // Check that host bits are zero.
+        let bits = Bits::from_v6(addr);
+        if !bits.is_host_zero(len) {
+            return Err(PrefixError::NonZeroHost)
+        }
+
+        Ok(Prefix { family_and_len, bits })
+    }
+
+    /// Creates a new prefix zeroing out host bits.
+    pub fn new_relaxed(addr: IpAddr, len: u8) -> Result<Self, PrefixError> {
+        match addr {
+            IpAddr::V4(addr) => Self::new_v4_relaxed(addr, len),
+            IpAddr::V6(addr) => Self::new_v6_relaxed(addr, len),
+        }
+    }
+
+    /// Creates a new prefix zeroing out host bits.
+    pub fn new_v4_relaxed(
+        addr: Ipv4Addr, len: u8
+    ) -> Result<Self, PrefixError> {
+        let family_and_len = FamilyAndLen::new_v4(len)?;
+        Ok(Prefix {
+            bits: Bits::from_v4(addr).clear_host(len),
+            family_and_len
+        })
+    }
+
+    /// Creates a new prefix zeroing out host bits.
+    pub fn new_v6_relaxed(
+        addr: Ipv6Addr, len: u8
+    ) -> Result<Self, PrefixError> {
+        let family_and_len = FamilyAndLen::new_v6(len)?;
+        Ok(Prefix {
+            bits: Bits::from_v6(addr).clear_host(len),
+            family_and_len
+        })
+    }
+
+    /// Returns whether the prefix is for an IPv4 address.
+    pub fn is_v4(self) -> bool {
+        self.family_and_len.is_v4()
+    }
+
+    /// Returns whether the prefix is for an IPv6 address.
+    pub fn is_v6(self) -> bool {
+        self.family_and_len.is_v6()
+    }
+
+    /// Returns the IP address part of a prefix.
+    pub fn addr(self) -> IpAddr {
+        if self.is_v4() {
+            self.bits.into_v4().into()
+        }
+        else {
+            self.bits.into_v6().into()
+        }
+    }
+
+    /// Returns the length part of a prefix.
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(self) -> u8 {
+        self.family_and_len.len()
+    }
+
+    /// Returns the prefix as a pair of the address and length.
+    pub fn addr_and_len(self) -> (IpAddr, u8) {
+        (self.addr(), self.len())
+    }
+
+    /// Returns the smallest address of the prefix.
+    ///
+    /// This is the same as [`addr`][Self::addr].
+    pub fn min_addr(self) -> IpAddr {
+        self.addr()
+    }
+
+    /// Returns the largest address of the prefix.
+    pub fn max_addr(self) -> IpAddr {
+        let bits = self.bits.into_max(self.len());
+        if self.is_v4() {
+            bits.into_v4().into()
+        }
+        else {
+            bits.into_v6().into()
+        }
+    }
+
+    /// Returns whether the prefix `self` covers the prefix `other`.
+    pub fn covers(self, other: Self) -> bool {
+        // Differing families? Not covering.
+        if self.is_v4() != other.is_v4() {
+            return false
+        }
+
+        // If self is more specific than other, it can’t cover it.
+        if self.len() > other.len() {
+            return false
+        }
+
+        // If we have two host prefixes, they need to be identical.
+        // (This needs to be extra because the bit shifting below doesn’t
+        // work at least in the v6 case.)
+        if self.is_v4() {
+            if self.len() == 32 && other.len() == 32 {
+                return self == other
+            }
+        }
+        else if self.len() == 128 && other.len() == 128 {
+            return self == other
+        }
+
+        // other now needs to start with the same bits as self.
+        self.bits.into_int()
+            ==  other.bits.into_int() & !(u128::MAX >> self.len())
+    }
+}
+
+//--- PartialOrd and Ord
+
+/// See [Ordering](Prefix#ordering) in the type documentation.
+impl PartialOrd for Prefix { 
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// See [Ordering](Prefix#ordering) in the type documentation.
+impl Ord for Prefix {
+    fn cmp(&self, other: &Self) -> Ordering {
+
+        match (self.is_v4(), other.is_v4()) {
+            (true, false) => Ordering::Less, // v4 v6
+            (false, true) => Ordering::Greater, //v6 v4
+            // v4 v4 or v6 v6
+            (_, _) => {
+                if self.len() == other.len() {
+                    self.bits.0.cmp(&other.bits.0)
+                }
+                else {
+                    let minlen = std::cmp::min(self.len(), other.len());
+                    let mask = !(u128::MAX >> minlen);
+                    if self.bits.0 & mask == other.bits.0 & mask {
+                        // more-specific before less-specific
+                        other.len().cmp(&self.len()) 
+                    } else {
+                        self.bits.0.cmp(&other.bits.0)
+                    }
+                }
+            }
+        }
+    }
+}
+
+//--- From
+
+#[cfg(feature = "repository")]
+impl From<crate::repository::roa::FriendlyRoaIpAddress> for Prefix {
+    fn from(addr: crate::repository::roa::FriendlyRoaIpAddress) -> Self {
+        Prefix::new(
+            addr.address(), addr.address_length()
+        ).expect("ROA IP address with illegal prefix length")
+    }
+}
+
+#[cfg(feature = "repository")]
+impl From<Prefix> for crate::repository::resources::IpBlock {
+    fn from(src: Prefix) -> Self {
+        crate::repository::resources::Prefix::new(
+            src.addr(), src.len()
+        ).into()
+    }
+}
+
+
+//--- Deserialize and Serialize
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Prefix {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D
+    ) -> Result<Self, D::Error> {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = Prefix;
+
+            fn expecting(
+                &self, formatter: &mut fmt::Formatter
+            ) -> fmt::Result {
+                write!(formatter, "a string with an IPv4 or IPv6 prefix")
+            }
+
+            fn visit_str<E: serde::de::Error>(
+                self, v: &str
+            ) -> Result<Self::Value, E> {
+                Prefix::from_str(v).map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_str(Visitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Prefix {
+    fn serialize<S: serde::Serializer>(
+        &self, serializer: S
+    ) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+
+//--- FromStr and Display
+
+impl FromStr for Prefix {
+    type Err = ParsePrefixError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(ParsePrefixError::Empty)
+        }
+        let slash = s.find('/').ok_or(ParsePrefixError::MissingLen)?;
+        let addr = IpAddr::from_str(&s[..slash]).map_err(
+            ParsePrefixError::InvalidAddr
+        )?;
+        let len = u8::from_str(&s[slash + 1..]).map_err(
+            ParsePrefixError::InvalidLen
+        )?;
+        Prefix::new(addr, len).map_err(ParsePrefixError::InvalidPrefix)
+    }
+}
+
+impl fmt::Display for Prefix {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}/{}", self.addr(), self.len())
+    }
+}
+
+
+//--- Arbitrary
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Prefix {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>
+    ) -> arbitrary::Result<Self> {
+        let fal = FamilyAndLen::arbitrary(u)?;
+        let mut bits = Bits::arbitrary(u)?;
+        if fal.is_v4() {
+            bits.0 <<= 96;
+        }
+        Ok(Self {
+            family_and_len: fal,
+            bits: bits.clear_host(fal.len())
+        })
+    }
+}
+
+
+
+//------------ MaxLenPrefix --------------------------------------------------
+
+/// The pair of a prefix and an optional max-len.
+///
+/// # Ordering
+/// The ordering of MaxLenPrefixes is similar to the [ordering of
+/// Prefixes](Prefix#Ordering). The only difference is the optional MaxLen.
+/// When two prefixes are equal but differ in (presence of) max_len, the order
+/// is as follows:
+/// - any max_len always comes before no max_len
+/// - a larger (higher) max_len comes before a smaller (lower) max_len (e.g.
+/// 24 comes before 20). This is analog to how more-specifics come before
+/// less-specifics.
+///
+/// Note that the max_len can either be equal to the prefix length (with no
+/// practical difference from an omitted max_len) or larger than the prefix
+/// length. The max_len can not be smaller than the prefix length. Because of
+/// that, we can safely order 'any max_len' before 'no max_len' for equal
+/// prefixes.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct MaxLenPrefix {
+    /// The prefix.
+    prefix: Prefix,
+
+    /// The optional maximum prefix length.
+    max_len: Option<u8>,
+}
+
+impl MaxLenPrefix {
+    /// Creates a new value.
+    ///
+    /// The function returns an error if `max_len` is present and smaller than
+    /// `prefix.len()` or larger than the maximum prefix length of the
+    /// prefix’s address family.
+    pub fn new(
+        prefix: Prefix, max_len: Option<u8>
+    ) -> Result<Self, MaxLenError> {
+        if let Some(max_len) = max_len {
+            if
+                (prefix.is_v4() && max_len > 32)
+                || max_len > 128
+            {
+                return Err(MaxLenError::Overflow)
+            }
+            if prefix.len() > max_len {
+                return Err(MaxLenError::Underflow)
+            }
+        }
+        Ok(MaxLenPrefix { prefix, max_len })
+    }
+
+    /// Creates a value curtailing any out-of-bounds max-len.
+    pub fn saturating_new(prefix: Prefix, max_len: Option<u8>) -> Self {
+        let max_len = max_len.map(|max_len| {
+            if prefix.len() > max_len {
+                prefix.len()
+            }
+            else if prefix.is_v4() && max_len > 32 {
+                32
+            }
+            else if max_len > 128 {
+                128
+            }
+            else {
+                max_len
+            }
+        });
+        MaxLenPrefix { prefix, max_len }
+    }
+
+    /// Returns the actual prefix.
+    pub fn prefix(self) -> Prefix {
+        self.prefix
+    }
+
+    /// Returns the address of the prefix.
+    pub fn addr(self) -> IpAddr {
+        self.prefix.addr()
+    }
+
+    /// Returns the prefix length.
+    pub fn prefix_len(self) -> u8 {
+        self.prefix.len()
+    }
+
+    /// Returns the max-length.
+    pub fn max_len(self) -> Option<u8> {
+        self.max_len
+    }
+
+    /// Returns the max-length or the prefix-length if there is no max-length.
+    pub fn resolved_max_len(self) -> u8 {
+        self.max_len.unwrap_or_else(|| self.prefix.len())
+    }
+}
+
+/// See [Ordering](MaxLenPrefix#ordering) in the type documentation.
+impl PartialOrd for MaxLenPrefix { 
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// See [Ordering](MaxLenPrefix#ordering) in the type documentation.
+impl Ord for MaxLenPrefix {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.prefix.cmp(&other.prefix) {
+            Ordering::Less => Ordering::Less,
+            Ordering::Greater => Ordering::Greater,
+            Ordering::Equal => {
+                match (self.max_len, other.max_len) {
+                    (None, None) => Ordering::Equal,
+                    (Some(_), None) => Ordering::Less,
+                    (None, Some(_)) => Ordering::Greater,
+                    (Some(n), Some(m)) => m.cmp(&n)
+                }
+            }
+        }
+    }
+}
+
+//--- From
+
+impl From<Prefix> for MaxLenPrefix {
+    fn from(prefix: Prefix) -> Self {
+        MaxLenPrefix { prefix, max_len: None }
+    }
+}
+
+
+//--- FromStr and Display
+
+impl FromStr for MaxLenPrefix {
+    type Err = ParseMaxLenPrefixError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (prefix, max_len) = match s.find('-') {
+            Some(dash) => {
+                (
+                    Prefix::from_str(&s[..dash]).map_err(
+                        ParseMaxLenPrefixError::InvalidPrefix
+                    )?,
+                    Some(u8::from_str(&s[dash + 1..]).map_err(
+                        ParseMaxLenPrefixError::InvalidMaxLenFormat
+                    )?)
+                )
+            }
+            None => {
+                let prefix = Prefix::from_str(s).map_err(
+                    ParseMaxLenPrefixError::InvalidPrefix
+                )?;
+                (prefix, None)
+            }
+        };
+        Self::new(prefix, max_len).map_err(
+            ParseMaxLenPrefixError::InvalidMaxLenValue
+        )
+    }
+}
+
+impl fmt::Display for MaxLenPrefix {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.prefix())?;
+        if let Some(max_len) = self.max_len {
+            write!(f, "-{}", max_len)?;
+        }
+        Ok(())
+    }
+}
+
+
+//============ Errors ========================================================
+
+//------------ PrefixError ---------------------------------------------------
+
+/// Creating a prefix has failed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum PrefixError {
+    /// The prefix length is longer than allowed for the address family.
+    LenOverflow,
+
+    /// The host portion of the address has non-zero bits set.
+    NonZeroHost,
+}
+
+impl PrefixError {
+    /// Returns a static error message.
+    pub fn static_description(self) -> &'static str {
+        match self {
+            PrefixError::LenOverflow => "prefix length too large",
+            PrefixError::NonZeroHost => "non-zero host portion",
+        }
+    }
+}
+
+impl From<PrefixError> for &'static str {
+    fn from(err: PrefixError) -> Self {
+        err.static_description()
+    }
+}
+
+impl fmt::Display for PrefixError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.static_description())
+    }
+}
+
+impl error::Error for PrefixError { }
+
+
+//------------ ParsePrefixError ----------------------------------------------
+
+/// Creating an IP address prefix from a string has failed.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ParsePrefixError {
+    /// The value parsed was empty.
+    Empty,
+
+    /// The length portion after a slash was missing.
+    MissingLen,
+
+    /// The address portion is invalid.
+    InvalidAddr(AddrParseError),
+
+    /// The length portion is invalid.
+    InvalidLen(ParseIntError),
+
+    /// The combined prefix is invalid.
+    InvalidPrefix(PrefixError),
+}
+
+impl fmt::Display for ParsePrefixError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ParsePrefixError::Empty => f.write_str("empty string"),
+            ParsePrefixError::MissingLen => {
+                f.write_str("missing length portion")
+            }
+            ParsePrefixError::InvalidAddr(err) => {
+                write!(f, "invalid address: {}", err)
+            }
+            ParsePrefixError::InvalidLen(err) => {
+                write!(f, "invalid length: {}", err)
+            }
+            ParsePrefixError::InvalidPrefix(err) => err.fmt(f),
+        }
+    }
+}
+
+impl error::Error for ParsePrefixError { }
+
+
+//------------ MaxLenError ---------------------------------------------------
+
+/// A max-len prefix was constructed from illegal components.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum MaxLenError {
+    /// The max-len is larger than allowed for the address family.
+    Overflow,
+
+    /// The max-len is smaller than the prefix length.
+    Underflow,
+}
+
+impl MaxLenError {
+    /// Returns a static error message.
+    pub fn static_description(self) -> &'static str {
+        match self {
+            MaxLenError::Overflow => "max-length too large",
+            MaxLenError::Underflow => "max-length smaller than prefix length",
+        }
+    }
+}
+
+impl From<MaxLenError> for &'static str {
+    fn from(err: MaxLenError) -> Self {
+        err.static_description()
+    }
+}
+
+impl fmt::Display for MaxLenError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            MaxLenError::Overflow => {
+                f.write_str("max-length too large")
+            }
+            MaxLenError::Underflow => {
+                f.write_str("max-length smaller than prefix length")
+            }
+        }
+    }
+}
+
+impl error::Error for MaxLenError { }
+
+
+//------------ ParseMaxLenPrefixError ----------------------------------------
+
+/// Creating an max-len prefix from a string has failed.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ParseMaxLenPrefixError {
+    /// Parsing the prefix portion failed.
+    InvalidPrefix(ParsePrefixError),
+
+    /// The max-len portion is invalid.
+    InvalidMaxLenFormat(ParseIntError),
+
+    /// The max-len value is invalid.
+    InvalidMaxLenValue(MaxLenError)
+}
+
+impl fmt::Display for ParseMaxLenPrefixError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ParseMaxLenPrefixError::InvalidPrefix(err) => {
+                err.fmt(f)
+            }
+            ParseMaxLenPrefixError::InvalidMaxLenFormat(err) => {
+                write!(f, "invalid max length: {}", err)
+            }
+            ParseMaxLenPrefixError::InvalidMaxLenValue(err) => {
+                err.fmt(f)
+            }
+        }
+    }
+}
+
+impl error::Error for ParseMaxLenPrefixError { }
+
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn good_family_and_len() {
+        for i in 0..=32 {
+            let fal = FamilyAndLen::new_v4(i).unwrap();
+            assert!(fal.is_v4());
+            assert!(!fal.is_v6());
+            assert_eq!(fal.len(), i)
+        }
+        for i in 0..=128 {
+            let fal = FamilyAndLen::new_v6(i).unwrap();
+            assert!(!fal.is_v4());
+            assert!(fal.is_v6());
+            assert_eq!(fal.len(), i)
+        }
+    }
+
+    #[test]
+    fn bad_family_and_len() {
+        for i in 33..=255 {
+            assert_eq!(
+                FamilyAndLen::new_v4(i),
+                Err(PrefixError::LenOverflow)
+            );
+        }
+        for i in 129..=255 {
+            assert_eq!(
+                FamilyAndLen::new_v6(i),
+                Err(PrefixError::LenOverflow)
+            );
+        }
+    }
+
+    #[test]
+    fn from_conversions() {
+        assert_eq!(u128::from(Bits::from(0xabcdefu128)), 0xabcdefu128);
+        assert_eq!(
+            Ipv6Addr::from(Bits::from(0xabcdefu128)),
+            Ipv6Addr::from(0xabcdefu128)
+        );
+
+        assert_eq!(
+            Ipv4Addr::from(Bits::from(
+                    (192u128 << 24 | (168 << 16) | (10 << 8) | 20) << 96
+                    )),
+            Ipv4Addr::new(192, 168, 10, 20),
+        );
+
+        let ip4 = Ipv4Addr::new(192, 168, 10, 20);
+        assert_eq!(Ipv4Addr::from(Bits::from(ip4)), ip4);
+    }
+
+    #[test]
+    fn prefix_from_str() {
+        assert_eq!(
+            Prefix::from_str("127.0.0.0/12").unwrap().addr_and_len(),
+            (IpAddr::from_str("127.0.0.0").unwrap(), 12)
+        );
+        assert_eq!(
+            Prefix::from_str("2001:db8:10:20::/64").unwrap().addr_and_len(),
+            (IpAddr::from_str("2001:db8:10:20::").unwrap(), 64)
+        );
+        assert_eq!(
+            Prefix::from_str("0.0.0.0/0").unwrap().addr_and_len(),
+            (IpAddr::from_str("0.0.0.0").unwrap(), 0)
+        );
+        assert_eq!(
+            Prefix::from_str("::/0").unwrap().addr_and_len(),
+            (IpAddr::from_str("::").unwrap(), 0)
+        );
+
+        assert_eq!(
+            Prefix::from_str("127.0.0.0"),
+            Err(ParsePrefixError::MissingLen)
+        );
+        assert_eq!(
+            Prefix::from_str("2001:db8::"),
+            Err(ParsePrefixError::MissingLen)
+        );
+        assert!(
+            matches!(
+                Prefix::from_str("127.0.0.0/"),
+                Err(ParsePrefixError::InvalidLen(_))
+            )
+        );
+        assert!(
+            matches!(
+                Prefix::from_str("2001:db8::/"),
+                Err(ParsePrefixError::InvalidLen(_))
+            )
+        );
+        assert!(
+            matches!(
+                Prefix::from_str(""),
+                Err(ParsePrefixError::Empty)
+            )
+        );
+    }
+
+    #[test]
+    fn ordering() {
+        assert!(
+            Prefix::from_str("192.168.10.0/24").unwrap()
+                < Prefix::from_str("192.168.20.0/24").unwrap()
+        );
+        assert!(
+            Prefix::from_str("192.168.10.0/24").unwrap()
+                < Prefix::from_str("192.168.20.0/32").unwrap()
+        );
+
+        assert!(
+            Prefix::from_str("192.168.10.0/24").unwrap()
+                > Prefix::from_str("192.168.9.0/25").unwrap()
+        );
+        assert!(
+            Prefix::from_str("192.168.10.0/24").unwrap()
+                < Prefix::from_str("192.0.0.0/8").unwrap()
+        );
+
+        assert!(
+            Prefix::from_str("127.0.0.1/32").unwrap()
+                < Prefix::from_str("::/128").unwrap()
+        );
+        assert!(
+            Prefix::from_str("127.0.0.1/32").unwrap()
+                < Prefix::from_str("::/0").unwrap()
+        );
+
+        assert!(
+            Prefix::from_str("2001:db8:10:20::/64").unwrap()
+                < Prefix::from_str("2001:db8::/32").unwrap()
+        );
+        assert!(
+            Prefix::from_str("2001:db8:10:20::/64").unwrap()
+                < Prefix::from_str("2001:db8:10:30::/64").unwrap()
+        );
+
+        assert!(
+            Prefix::from_str("127.0.0.1/32").unwrap()
+                < Prefix::from_str("2001:ff00::/24").unwrap()
+        );
+        assert!(
+            Prefix::from_str("2001:ff00::/24").unwrap()
+                > Prefix::from_str("127.0.0.1/32").unwrap()
+        );
+
+        assert!(matches!(
+            Prefix::from_str("0.0.0.0/0")
+                .unwrap()
+                .cmp(&Prefix::from_str("0.0.0.0/0").unwrap()),
+            Ordering::Equal
+        ));
+
+        assert!(matches!(
+            Prefix::from_str("192.168.1.2/32")
+                .unwrap()
+                .cmp(&Prefix::from_str("192.168.1.2/32").unwrap()),
+            Ordering::Equal
+        ));
+
+        assert!(matches!(
+            Prefix::from_str("::/0")
+                .unwrap()
+                .cmp(&Prefix::from_str("::/0").unwrap()),
+            Ordering::Equal
+        ));
+
+        assert!(matches!(
+            Prefix::from_str("2001:db8:e000::/40")
+                .unwrap()
+                .cmp(&Prefix::from_str("2001:db8:e000::/40").unwrap()),
+            Ordering::Equal
+        ));
+
+        assert!(matches!(
+            Prefix::from_str("2001:db8::1/128")
+                .unwrap()
+                .cmp(&Prefix::from_str("2001:db8::1/128").unwrap()),
+            Ordering::Equal
+        ));
+
+        assert!(
+            Prefix::from_str("0.0.0.0/0").unwrap()
+                < Prefix::from_str("::/0").unwrap()
+        );
+        assert!(
+            Prefix::from_str("::/0").unwrap()
+                > Prefix::from_str("0.0.0.0/0").unwrap()
+        );
+    }
+
+    #[test]
+    fn prefixes() {
+        assert!(Prefix::new_v4(Ipv4Addr::from(0xffff0000), 16).is_ok());
+        assert!(
+            Prefix::new_v6(Ipv6Addr::from(0x2001_0db8_1234 << 80), 48).is_ok()
+        );
+        assert!(matches!(
+            Prefix::new_v4(Ipv4Addr::from(0xffffcafe), 16),
+            Err(PrefixError::NonZeroHost)
+        ));
+        assert!(matches!(
+            Prefix::new_v6(Ipv6Addr::from(0x2001_0db8_1234 << 80), 32),
+            Err(PrefixError::NonZeroHost)
+        ));
+    }
+
+    #[test]
+    fn ordering_maxlenprefixes() {
+        assert!(
+            matches!(
+                MaxLenPrefix::from_str("192.168.0.0/16-16").unwrap().cmp(
+                    &MaxLenPrefix::from_str("192.168.0.0/16-16").unwrap()),
+                    Ordering::Equal
+            )
+        );
+        assert!(
+            matches!(
+                MaxLenPrefix::from_str("192.168.0.0/16").unwrap().cmp(
+                    &MaxLenPrefix::from_str("192.168.0.0/16").unwrap()),
+                    Ordering::Equal
+            )
+        );
+        assert!(
+            MaxLenPrefix::from_str("192.168.0.0/16-24").unwrap() <
+            MaxLenPrefix::from_str("192.168.0.0/16").unwrap()
+        );
+        assert!(
+            MaxLenPrefix::from_str("192.168.0.0/16-16").unwrap() <
+            MaxLenPrefix::from_str("192.168.0.0/16").unwrap()
+        );
+        assert!(
+            MaxLenPrefix::from_str("192.168.0.0/16").unwrap() >
+            MaxLenPrefix::from_str("192.168.0.0/16-16").unwrap()
+        );
+
+        assert!(
+            MaxLenPrefix::from_str("10.9.0.0/16").unwrap() <
+            MaxLenPrefix::from_str("10.10.0.0/16-24").unwrap()
+        );
+        assert!(
+            MaxLenPrefix::from_str("10.10.0.0/16").unwrap() >
+            MaxLenPrefix::from_str("10.9.0.0/16-24").unwrap()
+        );
+    }
+
+    #[test]
+    fn relaxed_prefixes() {
+        assert_eq!(
+            Prefix::new_relaxed(
+                "192.168.10.20".parse::<IpAddr>().unwrap(), 16)
+            .unwrap(),
+            Prefix::new_v4_relaxed(
+                "192.168.10.20".parse::<Ipv4Addr>().unwrap(), 16)
+            .unwrap()
+        );
+        assert_eq!(
+            Prefix::new_relaxed(
+                "192.168.10.20".parse::<IpAddr>().unwrap(), 16).unwrap(),
+            Prefix::new_relaxed(
+                "192.168.0.0".parse::<IpAddr>().unwrap(), 16).unwrap(),
+        );
+        assert_eq!(
+            Prefix::new_relaxed(
+                "2001:db8::10:20:30:40".parse::<IpAddr>().unwrap(), 64)
+            .unwrap(),
+            Prefix::new_v6_relaxed(
+                "2001:db8::10:20:30:40".parse::<Ipv6Addr>().unwrap(), 64)
+            .unwrap()
+        );
+        assert_eq!(
+            Prefix::new_relaxed(
+                "2001:db8::10:20:30:40".parse::<IpAddr>().unwrap(), 64)
+            .unwrap(),
+            Prefix::new_relaxed(
+                "2001:db8::".parse::<IpAddr>().unwrap(), 64)
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn min_max_addr() {
+        assert_eq!(
+            Prefix::from_str("192.168.0.0/16").unwrap().min_addr(),
+            IpAddr::from_str("192.168.0.0").unwrap()
+        );
+        assert_eq!(
+            Prefix::from_str("192.168.0.0/16").unwrap().max_addr(),
+            IpAddr::from_str("192.168.255.255").unwrap()
+        );
+        assert_eq!(
+            Prefix::from_str("192.168.1.1/32").unwrap().min_addr(),
+            IpAddr::from_str("192.168.1.1").unwrap()
+        );
+        assert_eq!(
+            Prefix::from_str("192.168.1.1/32").unwrap().min_addr(),
+            Prefix::from_str("192.168.1.1/32").unwrap().max_addr()
+        );
+
+        assert_eq!(
+            Prefix::from_str("2001:db8:10:20::/64").unwrap().min_addr(),
+            IpAddr::from_str("2001:db8:10:20::").unwrap()
+        );
+        assert_eq!(
+            Prefix::from_str("2001:db8:10:20::/64").unwrap().max_addr(),
+            IpAddr::from_str("2001:db8:10:20:ffff:ffff:ffff:ffff").unwrap()
+        );
+        assert_eq!(
+            Prefix::from_str("2001:db8:10:20::1234/128").unwrap().min_addr(),
+            IpAddr::from_str("2001:db8:10:20::1234").unwrap()
+        );
+        assert_eq!(
+            Prefix::from_str("2001:db8:10:20::1234/128").unwrap().min_addr(),
+            Prefix::from_str("2001:db8:10:20::1234/128").unwrap().max_addr()
+        );
+    }
+
+    #[test]
+    fn covers() {
+        assert!(Prefix::from_str("0.0.0.0/0").unwrap().covers(
+                Prefix::from_str("192.168.10.0/24").unwrap())
+        );
+        assert!(Prefix::from_str("::/0").unwrap().covers(
+                Prefix::from_str("2001:db8:10::/48").unwrap())
+        );
+
+        assert!(Prefix::from_str("192.168.0.0/16").unwrap().covers(
+                Prefix::from_str("192.168.10.0/24").unwrap())
+        );
+        assert!(!Prefix::from_str("192.168.10.0/24").unwrap().covers(
+                Prefix::from_str("192.168.0.0/16").unwrap())
+        );
+        assert!(Prefix::from_str("2001:db8:10::/48").unwrap().covers(
+                Prefix::from_str("2001:db8:10:20::/64").unwrap())
+        );
+        assert!(!Prefix::from_str("2001:db8:10:20::/64").unwrap().covers(
+                Prefix::from_str("2001:db8:10::/48").unwrap())
+        );
+
+        assert!(Prefix::from_str("192.168.10.1/32").unwrap().covers(
+                Prefix::from_str("192.168.10.1/32").unwrap())
+        );
+        assert!(!Prefix::from_str("192.168.10.1/32").unwrap().covers(
+                Prefix::from_str("192.168.10.2/32").unwrap())
+        );
+        assert!(Prefix::from_str("2001:db8:10::1234/128").unwrap().covers(
+                Prefix::from_str("2001:db8:10::1234/128").unwrap())
+        );
+        assert!(!Prefix::from_str("2001:db8:10::abcd/128").unwrap().covers(
+                Prefix::from_str("2001:db8:10::1234/128").unwrap())
+        );
+
+
+        assert!(!Prefix::from_str("192.168.10.0/24").unwrap().covers(
+                Prefix::from_str("2001:db8::1/128").unwrap())
+        );
+        assert!(!Prefix::from_str("2001:db8::1/128").unwrap().covers(
+                Prefix::from_str("192.168.10.0/24").unwrap())
+        );
+    }
+
+    #[test]
+    fn max_len_prefix() {
+        let pfx4 = Prefix::from_str("192.168.0.0/16").unwrap();
+        let pfx6 = Prefix::from_str("2001:db8:10::/48").unwrap();
+
+        assert!(MaxLenPrefix::new(pfx4, Some(24)).is_ok());
+        assert!(MaxLenPrefix::new(pfx4, Some(32)).is_ok());
+        assert!(MaxLenPrefix::new(pfx6, Some(64)).is_ok());
+        assert!(MaxLenPrefix::new(pfx6, Some(128)).is_ok());
+
+        assert_eq!(MaxLenPrefix::from(pfx4).prefix_len(), 16);
+        assert_eq!(MaxLenPrefix::from(pfx4).prefix(), pfx4);
+        assert_eq!(MaxLenPrefix::from(pfx4).max_len(), None);
+        assert_eq!(MaxLenPrefix::from(pfx4).resolved_max_len(), 16);
+
+        assert_eq!(MaxLenPrefix::from(pfx6).prefix_len(), 48);
+        assert_eq!(MaxLenPrefix::from(pfx6).prefix(), pfx6);
+        assert_eq!(MaxLenPrefix::from(pfx6).max_len(), None);
+        assert_eq!(MaxLenPrefix::from(pfx6).resolved_max_len(), 48);
+
+        assert!(matches!(
+            MaxLenPrefix::new(pfx4, Some(12)),
+            Err(MaxLenError::Underflow)
+        ));
+        assert!(matches!(
+            MaxLenPrefix::new(pfx4, Some(33)),
+            Err(MaxLenError::Overflow)
+        ));
+        assert!(matches!(
+            MaxLenPrefix::new(pfx6, Some(32)),
+            Err(MaxLenError::Underflow)
+        ));
+        assert!(matches!(
+            MaxLenPrefix::new(pfx6, Some(130)),
+            Err(MaxLenError::Overflow)
+        ));
+
+
+        for i in 0..16 {
+            assert_eq!(
+                MaxLenPrefix::saturating_new(pfx4, Some(i)),
+                MaxLenPrefix::new(pfx4, Some(16)).unwrap()
+            );
+        }
+        for i in 16..=32 {
+            assert_eq!(
+                MaxLenPrefix::saturating_new(pfx4, Some(i)),
+                MaxLenPrefix::new(pfx4, Some(i)).unwrap()
+            );
+        }
+        for i in 33..=255 {
+            assert_eq!(
+                MaxLenPrefix::saturating_new(pfx4, Some(i)),
+                MaxLenPrefix::new(pfx4, Some(32)).unwrap()
+            );
+        }
+        for i in 0..48 {
+            assert_eq!(
+                MaxLenPrefix::saturating_new(pfx6, Some(i)),
+                MaxLenPrefix::new(pfx6, Some(48)).unwrap()
+            );
+        }
+        for i in 48..=128 {
+            assert_eq!(
+                MaxLenPrefix::saturating_new(pfx6, Some(i)),
+                MaxLenPrefix::new(pfx6, Some(i)).unwrap()
+            );
+        }
+        for i in 129..=255 {
+            assert_eq!(
+                MaxLenPrefix::saturating_new(pfx6, Some(i)),
+                MaxLenPrefix::new(pfx6, Some(128)).unwrap()
+            );
+        }
+
+        assert_eq!(
+            MaxLenPrefix::new(pfx6, Some(56)).unwrap().resolved_max_len(),
+            56
+        );
+        assert_eq!(
+            MaxLenPrefix::new(pfx6, None).unwrap().resolved_max_len(),
+            48
+        );
+
+        assert_eq!(
+            MaxLenPrefix::from_str("192.168.0.0/16-24").unwrap(),
+            MaxLenPrefix::new(pfx4, Some(24)).unwrap()
+        );
+        assert_eq!(
+            MaxLenPrefix::from_str("192.168.0.0/16").unwrap(),
+            MaxLenPrefix::new(pfx4, None).unwrap()
+        );
+        assert!(
+            matches!(
+                MaxLenPrefix::from_str("192.168.0.0/16-"),
+                Err(ParseMaxLenPrefixError::InvalidMaxLenFormat(_))
+            )
+        );
+        assert!(
+            matches!(
+                MaxLenPrefix::from_str("192.168.0.0/16-0"),
+                Err(ParseMaxLenPrefixError::InvalidMaxLenValue(_))
+            )
+        );
+        assert!(
+            matches!(
+                MaxLenPrefix::from_str("192.168.0.0/16-33"),
+                Err(ParseMaxLenPrefixError::InvalidMaxLenValue(_))
+            )
+        );
+    }
+
+    #[test]
+    fn max_len_prefix_display() {
+        assert_eq!(
+            format!(
+                "{}", MaxLenPrefix::from_str("192.168.0.0/16-32").unwrap()
+            ).as_str(),
+            "192.168.0.0/16-32"
+        );
+        assert_eq!(
+            format!(
+                "{}", MaxLenPrefix::from_str("192.168.0.0/16").unwrap()
+            ).as_str(),
+            "192.168.0.0/16"
+        );
+    }
+
+    #[test]
+    fn clear_host_of_zero_len_prefix() {
+        assert_eq!(Bits(0), Bits(12345).clear_host(0));
+    }
+}

--- a/src/resources/asn.rs
+++ b/src/resources/asn.rs
@@ -1,0 +1,1179 @@
+//! Types for Autonomous Systems Numbers (ASN) and ASN collections
+
+use std::{error, fmt, iter, ops, slice};
+use std::cmp::Ordering;
+use std::convert::{TryFrom, TryInto};
+use std::str::FromStr;
+use std::iter::Peekable;
+
+#[cfg(feature = "bcder")]
+use bcder::decode::{self, DecodeError, Source};
+
+
+//------------ Asn -----------------------------------------------------------
+
+/// An AS number (ASN).
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct Asn(u32);
+
+impl Asn {
+    pub const MIN: Asn = Asn(std::u32::MIN);
+    pub const MAX: Asn = Asn(std::u32::MAX);
+
+    /// Creates an AS number from a `u32`.
+    pub fn from_u32(value: u32) -> Self {
+        Asn(value)
+    }
+
+    /// Converts an AS number into a `u32`.
+    pub fn into_u32(self) -> u32 {
+        self.0
+    }
+
+    /// Converts an AS number into a network-order byte array.
+    pub fn to_raw(self) -> [u8; 4] {
+        self.0.to_be_bytes()
+    }
+}
+
+#[cfg(feature = "bcder")]
+impl Asn {
+    /// Takes an AS number from the beginning of an encoded value.
+    pub fn take_from<S: Source>(
+        cons: &mut decode::Constructed<S>
+    ) -> Result<Self, DecodeError<S::Error>> {
+        cons.take_u32().map(Asn)
+    }
+
+    /// Skips over an AS number at the beginning of an encoded value.
+    pub fn skip_in<S: Source>(
+        cons: &mut decode::Constructed<S>
+    ) -> Result<(), DecodeError<S::Error>> {
+        cons.take_u32().map(|_| ())
+    }
+
+    /// Parses the content of an AS number value.
+    pub fn parse_content<S: Source>(
+        content: &mut decode::Content<S>,
+    ) -> Result<Self, DecodeError<S::Error>> {
+        content.to_u32().map(Asn)
+    }
+
+    /// Skips the content of an AS number value.
+    pub fn skip_content<S: Source>(
+        content: &mut decode::Content<S>
+    ) -> Result<(), DecodeError<S::Error>> {
+        content.to_u32().map(|_| ())
+    }
+
+    pub fn encode(self) -> impl bcder::encode::Values {
+        bcder::encode::PrimitiveContent::encode(self.0)
+    }
+}
+
+//--- From
+
+impl From<u32> for Asn {
+    fn from(id: u32) -> Self {
+        Asn(id)
+    }
+}
+
+impl From<Asn> for u32 {
+    fn from(id: Asn) -> Self {
+        id.0
+    }
+}
+
+//--- FromStr
+
+impl FromStr for Asn {
+    type Err = ParseAsnError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = if s.len() > 2 && s[..2].eq_ignore_ascii_case("as") {
+            &s[2..]
+        } else {
+            s
+        };
+
+        u32::from_str(s).map(Asn).map_err(|_| ParseAsnError)
+    }
+}
+
+
+//--- Serialize and Deserialize
+
+/// # Serialization
+///
+/// With the `"serde"` feature enabled, `Asn` implements the `Serialize` and
+/// `Deserialize` traits via _serde-derive_ as a newtype wrapping a `u32`.
+///
+/// However, ASNs are often serialized as a string prefix with `AS`. In order
+/// to allow this, a number of methods are provided that can be used with
+/// Serde’s field attributes to choose how to serialize an ASN as part of a
+/// struct.
+#[cfg(feature = "serde")]
+impl Asn {
+    /// Serializes an AS number as a simple `u32`.
+    ///
+    /// Normally, you wouldn’t need to use this method, as the default
+    /// implementation serializes the ASN as a newtype struct with a `u32`
+    /// inside which most serialization formats will turn into a sole `u32`.
+    /// However, in case your format doesn’t, you can use this method.
+    pub fn serialize_as_u32<S: serde::Serializer>(
+        &self, serializer: S
+    ) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u32(self.0)
+    }
+
+    /// Serializes an AS number as a string without prefix.
+    pub fn serialize_as_bare_str<S: serde::Serializer>(
+        &self, serializer: S
+    ) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(&format_args!("{}", self.0))
+    }
+
+    /// Seriaizes an AS number as a string with a `AS` prefix.
+    pub fn serialize_as_str<S: serde::Serializer>(
+        &self, serializer: S
+    ) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(&format_args!("AS{}", self.0))
+    }
+
+    /// Deserializes an AS number from a simple `u32`.
+    ///
+    /// Normally, you wouldn’t need to use this method, as the default
+    /// implementation deserializes the ASN from a newtype struct with a
+    /// `u32` inside for which most serialization formats will use a sole
+    /// `u32`. However, in case your format doesn’t, you can use this method.
+    pub fn deserialize_from_u32<'de, D: serde::Deserializer<'de>>(
+        deserializer: D
+    ) -> Result<Self, D::Error> {
+        <u32 as serde::Deserialize>::deserialize(deserializer).map(Into::into)
+    }
+
+    /// Deserializes an AS number from a string.
+    ///
+    /// The string may or may not have a case-insensitive `"AS"` prefix.
+    pub fn deserialize_from_str<'de, D: serde::de::Deserializer<'de>>(
+        deserializer: D
+    ) -> Result<Self, D::Error> {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = Asn;
+
+            fn expecting(
+                &self, formatter: &mut fmt::Formatter
+            ) -> fmt::Result {
+                write!(formatter, "an AS number")
+            }
+
+            fn visit_str<E: serde::de::Error>(
+                self, v: &str
+            ) -> Result<Self::Value, E> {
+                Asn::from_str(v).map_err(E::custom)
+            }
+        }
+        deserializer.deserialize_str(Visitor)
+    }
+
+    /// Deserializes an AS number as either a string or `u32`.
+    ///
+    /// This function can only be used with self-describing serialization
+    /// formats as it uses `Deserializer::deserialize_any`. It accepts an
+    /// AS number as any kind of integer as well as a string with or without
+    /// a case-insensitive `"AS"` prefix.
+    pub fn deserialize_from_any<'de, D: serde::de::Deserializer<'de>>(
+        deserializer: D
+    ) -> Result<Self, D::Error> {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = Asn;
+
+            fn expecting(
+                &self, formatter: &mut fmt::Formatter
+            ) -> fmt::Result {
+                write!(formatter, "an AS number")
+            }
+
+            fn visit_u8<E: serde::de::Error>(
+                self, v: u8
+            ) -> Result<Self::Value, E> {
+                Ok(Asn(v.into()))
+            }
+
+            fn visit_u16<E: serde::de::Error>(
+                self, v: u16
+            ) -> Result<Self::Value, E> {
+                Ok(Asn(v.into()))
+            }
+
+            fn visit_u32<E: serde::de::Error>(
+                self, v: u32
+            ) -> Result<Self::Value, E> {
+                Ok(Asn(v))
+            }
+
+            fn visit_u64<E: serde::de::Error>(
+                self, v: u64
+            ) -> Result<Self::Value, E> {
+                Ok(Asn(v.try_into().map_err(E::custom)?))
+            }
+
+            fn visit_i8<E: serde::de::Error>(
+                self, v: i8
+            ) -> Result<Self::Value, E> {
+                Ok(Asn(v.try_into().map_err(E::custom)?))
+            }
+
+            fn visit_i16<E: serde::de::Error>(
+                self, v: i16
+            ) -> Result<Self::Value, E> {
+                Ok(Asn(v.try_into().map_err(E::custom)?))
+            }
+
+            fn visit_i32<E: serde::de::Error>(
+                self, v: i32
+            ) -> Result<Self::Value, E> {
+                Ok(Asn(v.try_into().map_err(E::custom)?))
+            }
+
+            fn visit_i64<E: serde::de::Error>(
+                self, v: i64
+            ) -> Result<Self::Value, E> {
+                Ok(Asn(v.try_into().map_err(E::custom)?))
+            }
+
+            fn visit_str<E: serde::de::Error>(
+                self, v: &str
+            ) -> Result<Self::Value, E> {
+                Asn::from_str(v).map_err(E::custom)
+            }
+        }
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+//--- Add
+
+impl ops::Add<u32> for Asn {
+    type Output = Self;
+
+    fn add(self, rhs: u32) -> Self {
+        Asn(self.0.checked_add(rhs).unwrap())
+    }
+}
+
+//--- Display
+
+impl fmt::Display for Asn {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "AS{}", self.0)
+    }
+}
+
+
+//------------ SmallAsnSet --------------------------------------------------
+
+/// A relatively small set of ASNs.
+///
+/// This type is only efficient if the amount of ASNs in it is relatively
+/// small as it is represented internally by an ordered vec of ASNs to avoid
+/// memory overhead.
+#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct SmallAsnSet(Vec<Asn>);
+
+impl SmallAsnSet {
+    pub fn iter(&self) -> SmallSetIter {
+        self.0.iter().cloned()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn difference<'a>(
+        &'a self, other: &'a Self
+    ) -> SmallSetDifference<'a> {
+        SmallSetDifference {
+            left: self.iter().peekable(),
+            right: other.iter().peekable(),
+        }
+    }
+
+    pub fn symmetric_difference<'a>(
+        &'a self, other: &'a Self
+    ) -> SmallSetSymmetricDifference<'a> {
+        SmallSetSymmetricDifference {
+            left: self.iter().peekable(),
+            right: other.iter().peekable(),
+        }
+    }
+
+    pub fn intersection<'a>(
+        &'a self, other: &'a Self
+    ) -> SmallSetIntersection<'a> {
+        SmallSetIntersection {
+            left: self.iter().peekable(),
+            right: other.iter().peekable(),
+        }
+    }
+
+    pub fn union<'a>(&'a self, other: &'a Self) -> SmallSetUnion<'a> {
+        SmallSetUnion {
+            left: self.iter().peekable(),
+            right: other.iter().peekable(),
+        }
+    }
+
+    pub fn contains(&self, asn: Asn) -> bool {
+        self.0.binary_search(&asn).is_ok()
+    }
+
+    // Missing: is_disjoint, is_subset, is_superset, insert, remove,
+}
+
+
+impl iter::FromIterator<Asn> for SmallAsnSet {
+    fn from_iter<T: IntoIterator<Item = Asn>>(iter: T) -> Self {
+        let mut res = Self(iter.into_iter().collect());
+        res.0.sort();
+        res
+    }
+}
+
+impl<'a> IntoIterator for &'a SmallAsnSet {
+    type Item = Asn;
+    type IntoIter = SmallSetIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter().cloned()
+    }
+}
+
+
+//------------ SmallSetIter --------------------------------------------------
+
+pub type SmallSetIter<'a> = iter::Cloned<slice::Iter<'a, Asn>>;
+
+
+//------------ SmallSetDifference --------------------------------------------
+
+pub struct SmallSetDifference<'a> {
+    left: Peekable<SmallSetIter<'a>>,
+    right: Peekable<SmallSetIter<'a>>,
+}
+
+impl<'a> Iterator for SmallSetDifference<'a> {
+    type Item = Asn;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match (self.left.peek(), self.right.peek()) {
+                (None, _) => return None,
+                (Some(_), None) => return self.left.next(),
+                (Some(left), Some(right)) => {
+                    match left.cmp(right) {
+                        Ordering::Less => return self.left.next(),
+                        Ordering::Equal => {
+                            let _ = self.left.next();
+                            let _ = self.right.next();
+                        }
+                        Ordering::Greater => {
+                            let _ = self.right.next();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+//------------ SmallSetSymmetricDifference -----------------------------------
+
+pub struct SmallSetSymmetricDifference<'a> {
+    left: Peekable<SmallSetIter<'a>>,
+    right: Peekable<SmallSetIter<'a>>,
+}
+
+impl<'a> Iterator for SmallSetSymmetricDifference<'a> {
+    type Item = Asn;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match (self.left.peek(),self. right.peek()) {
+                (None, None) => return None,
+                (Some(_), None) => return self.left.next(),
+                (None, Some(_)) => return self.right.next(),
+                (Some(left), Some(right)) => {
+                    match left.cmp(right) {
+                        Ordering::Equal => {
+                            let _ = self.left.next();
+                            let _ = self.right.next();
+                        }
+                        Ordering::Less => return self.left.next(),
+                        Ordering::Greater => return self.right.next(),
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+//------------ SmallSetIntersection ------------------------------------------
+
+pub struct SmallSetIntersection<'a> {
+    left: Peekable<SmallSetIter<'a>>,
+    right: Peekable<SmallSetIter<'a>>,
+}
+
+impl<'a> Iterator for SmallSetIntersection<'a> {
+    type Item = Asn;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match (self.left.peek(),self. right.peek()) {
+                (None, _) | (_, None) => return None,
+                (Some(left), Some(right)) => {
+                    match left.cmp(right) {
+                        Ordering::Equal => {
+                            let _ = self.left.next();
+                            return self.right.next()
+                        }
+                        Ordering::Less => {
+                            let _ = self.left.next();
+                        }
+                        Ordering::Greater => {
+                            let _ = self.right.next();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+//------------ SmallSetUnion -------------------------------------------------
+
+pub struct SmallSetUnion<'a> {
+    left: Peekable<SmallSetIter<'a>>,
+    right: Peekable<SmallSetIter<'a>>,
+}
+
+impl<'a> Iterator for SmallSetUnion<'a> {
+    type Item = Asn;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.left.peek(),self. right.peek()) {
+            (None, None) => None,
+            (Some(_), None) => self.left.next(),
+            (None, Some(_)) => self.right.next(),
+            (Some(left), Some(right)) => {
+                match left.cmp(right) {
+                    Ordering::Less => self.left.next(),
+                    Ordering::Equal => {
+                        let _ = self.left.next();
+                        self.right.next()
+                    }
+                    Ordering::Greater => {
+                        self.right.next()
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+//============ AS PATH =======================================================
+//
+// This is being moved to its own module in `bgp` can can be removed here.
+
+
+//------------ PathSegment ---------------------------------------------------
+
+/// A segment of an AS path.
+#[derive(Debug, Clone, Copy)]
+pub struct PathSegment<'a> {
+    /// The type of the path segment.
+    stype: SegmentType,
+
+    /// The elements of the path segment.
+    elements: &'a [Asn],
+}
+
+impl<'a> PathSegment<'a> {
+    /// Creates a path segment from a type and a slice of elements.
+    fn new(stype: SegmentType, elements: &'a [Asn]) -> Self {
+        PathSegment { stype, elements }
+    }
+
+    /// Returns the type of the segment.
+    pub fn segment_type(self) -> SegmentType {
+        self.stype
+    }
+
+    /// Returns a slice with the elements of the segment.
+    pub fn elements(self) -> &'a [Asn] {
+        self.elements
+    }
+}
+
+
+//--- Display
+
+impl fmt::Display for PathSegment<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}(", self.stype)?;
+        if let Some((first, tail)) = self.elements.split_first() {
+            write!(f, "{}", first)?;
+            for elem in tail {
+                write!(f, ", {}", elem)?;
+            }
+        }
+        write!(f, ")")
+    }
+}
+
+
+//------------ SegmentType ---------------------------------------------------
+
+/// The type of a path segment.
+///
+/// This is a private helper type for encoding the type into, er, other
+/// things.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum SegmentType {
+    /// The segment is an AS_SET.
+    ///
+    /// An AS_SET is an unordered set of autonomous systems that a route in
+    /// an UPDATE BGP message has traversed.
+    Set,
+
+    /// The segment is an AS_SEQUENCE.
+    ///
+    /// An AS_SET is an ordered set of autonomous systems that a route in
+    /// an UPDATE BGP message has traversed.
+    Sequence,
+
+    /// The segment is an AS_CONFED_SEQUENCE.
+    ///
+    /// An AS_CONFED_SEQUENCE is an ordered set of Member Autonomous Systems
+    /// in the local confederation that the UPDATE message has traversed.
+    ConfedSequence,
+
+    /// The segment is an AS_CONFED_SET.
+    ///
+    /// An AS_CONFED_SET is an unordered set of Member Autonomous Systems
+    /// in the local confederation that the UPDATE message has traversed.
+    ConfedSet,
+}
+
+
+//--- TryFrom and From
+
+impl TryFrom<u8> for SegmentType {
+    type Error = InvalidSegmentTypeError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(SegmentType::Set),
+            2 => Ok(SegmentType::Sequence),
+            3 => Ok(SegmentType::ConfedSequence),
+            4 => Ok(SegmentType::ConfedSet),
+            _ => Err(InvalidSegmentTypeError)
+        }
+    }
+}
+
+impl From<SegmentType> for u8 {
+    fn from(value: SegmentType) -> u8 {
+        match value {
+            SegmentType::Set => 1,
+            SegmentType::Sequence => 2,
+            SegmentType::ConfedSequence => 3,
+            SegmentType::ConfedSet => 4,
+        }
+    }
+}
+
+
+//--- Display
+
+impl fmt::Display for SegmentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match *self {
+            SegmentType::Set => "AS_SET",
+            SegmentType::Sequence => "AS_SEQUENCE",
+            SegmentType::ConfedSequence => "AS_CONFED_SEQUENCE", 
+            SegmentType::ConfedSet => "AS_CONFED_SET",
+        })
+    }
+}
+
+
+//-------- AsPath ------------------------------------------------------------
+
+/// An AS path.
+///
+/// An AS path is a sequence of path segments. The type is generic over some
+/// type that provides access to a slice of `Asn`s.
+//
+//  As AS paths are really a sequence of sequences, we employ a bit of
+//  trickery to store them in a single sequence of `Asn`s. Specifically, each
+//  segment is preceded by a sentinel element describing the segment type and
+//  the length. Since we have a sequence of ASNs, we need to abuse `Asn` for
+//  this purpose. Both the type and the length are `u8`s in BGP, so there is
+//  plenty space in a 32 bit ASN for them. The specific encoding can be found
+//  in `decode_sentinel` and `encode_sentinel` below.
+//
+//  So, the first element in the path is a sentinel, followed by as many real
+//  ASNs as is encoded in the sentinel, followed by another sentinel and so
+//  on.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct AsPath<T> {
+    /// The segments of the path.
+    segments: T,
+}
+
+impl<T: AsRef<[Asn]>> AsPath<T> {
+    /// Returns an iterator over the segments of the path.
+    pub fn iter(&self) -> AsPath<&[Asn]> {
+        AsPath { segments: self.segments.as_ref() }
+    }
+    
+    /// Returns true if the path contains the given ASN.
+    pub fn contains(&self, asn: Asn) -> bool {
+        for segment in self.iter() {
+            if segment.elements().contains(&asn) {
+                return true
+            }
+        }
+        false
+    }
+}
+
+
+//--- IntoIterator and Iterator
+
+impl<'a, T: AsRef<[Asn]>> IntoIterator for &'a AsPath<T> {
+    type Item = PathSegment<'a>;
+    type IntoIter = AsPath<&'a [Asn]>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> Iterator for AsPath<&'a [Asn]> {
+    type Item = PathSegment<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (&first, segments) = self.segments.split_first()?;
+        let (stype, len) = decode_sentinel(first);
+        let (res, tail) = segments.split_at(len as usize);
+        self.segments = tail;
+        Some(PathSegment::new(stype, res))
+    }
+}
+
+
+//--- Display
+
+impl<T: AsRef<[Asn]>> fmt::Display for AsPath<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        for item in self {
+            if first {
+                write!(f, "{}", item)?;
+                first = false;
+            } else {
+                write!(f, ", {}", item)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+//------------ AsPathBuilder -------------------------------------------------
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AsPathBuilder {
+    /// A vec with the elements we have so far.
+    segments: Vec<Asn>,
+
+    /// The index of the head element of the currently build segment.
+    curr_start: usize,
+}
+
+impl AsPathBuilder {
+    /// Creates a new, empty AS path builder.
+    ///
+    /// The builder will start out with building an initial segement of
+    /// sequence type.
+    pub fn new() -> Self {
+        AsPathBuilder {
+            segments: vec![encode_sentinel(SegmentType::Sequence, 0)],
+            curr_start: 0,
+        }
+    }
+
+    /// Starts a new segment, closing the current one, if any.
+    pub fn start(&mut self, stype: SegmentType) {
+        let len = self.segment_len();
+        if len > 0 {
+            update_sentinel_len(
+                &mut self.segments[self.curr_start], len as u8
+            );
+            self.curr_start = self.segments.len();
+            self.segments.push(encode_sentinel(stype, 0));
+        }
+        else {
+            self.segments[self.curr_start] = encode_sentinel(stype, 0);
+        }
+    }
+
+    /// Returns the length of the currently built segment.
+    pub fn segment_len(&self) -> usize {
+        self.segments.len() - self.curr_start - 1
+    }
+
+    /// Appends an AS number to the currently built segment.
+    ///
+    /// This can fail if it would result in a segment that is longer than
+    /// 255 ASNs.
+    pub fn push(&mut self, asn: Asn) -> Result<(), LongSegmentError> {
+        if self.segment_len() == 255 {
+            return Err(LongSegmentError)
+        }
+        self.segments.push(asn);
+        Ok(())
+    }
+
+    /// Appends the content of a slice of ASNs to the currently built segment.
+    ///
+    /// This can fail if it would result in a segment that is longer than
+    /// 255 ASNs.
+    pub fn extend_from_slice(
+        &mut self, other: &[Asn]
+    ) -> Result<(), LongSegmentError> {
+        if self.segment_len() + other.len() > 255 {
+            return Err(LongSegmentError)
+        }
+        self.segments.extend_from_slice(other);
+        Ok(())
+    }
+
+    /// Finalizes and returns the AS path.
+    pub fn finalize<U: From<Vec<Asn>>>(mut self) -> AsPath<U> {
+        let len = self.segment_len();
+        if len > 0 {
+            update_sentinel_len(
+                &mut self.segments[self.curr_start], len as u8
+            );
+        }
+        AsPath { segments: self.segments.into() }
+    }
+}
+
+
+//--- Default
+
+impl Default for AsPathBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+
+//------------ ASN as path segment sentinel ----------------------------------
+
+/// Converts a sentinel `Asn` into a segment type and length.
+fn decode_sentinel(sentinel: Asn) -> (SegmentType, u8) {
+    (
+        ((sentinel.0 >> 8) as u8)
+            .try_into().expect("illegally encoded AS path"),
+        sentinel.0 as u8
+    )
+}
+
+/// Converts segment type and length into a sentinel `Asn`.
+fn encode_sentinel(t: SegmentType, len: u8) -> Asn {
+    Asn((u8::from(t) as u32) << 8 | (len as u32))
+}
+
+/// Updates the length portion of a sentinel `Asn`.
+fn update_sentinel_len(sentinel: &mut Asn, len: u8) {
+    sentinel.0 = (sentinel.0 & 0xFFFF_FF00) | len as u32
+}
+
+
+//============ Error Types ===================================================
+
+//------------ ParseAsnError ------------------------------------------------
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ParseAsnError;
+
+impl fmt::Display for ParseAsnError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("invalid AS number")
+    }
+}
+
+impl error::Error for ParseAsnError {}
+
+
+//------------ LongSegmentError ----------------------------------------------
+
+#[derive(Clone, Copy, Debug)]
+pub struct LongSegmentError;
+
+impl fmt::Display for LongSegmentError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("path segment too long")
+    }
+}
+
+impl error::Error for LongSegmentError { }
+
+
+//------------ InvalidSegmentTypeError ---------------------------------------
+
+#[derive(Clone, Copy, Debug)]
+pub struct InvalidSegmentTypeError;
+
+impl fmt::Display for InvalidSegmentTypeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("invalid segment type")
+    }
+}
+
+impl error::Error for InvalidSegmentTypeError { }
+
+
+//============ Tests =========================================================
+
+#[cfg(all(test, feature = "serde"))]
+mod test_serde {
+    use super::*;
+    use serde_test::{Token, assert_de_tokens, assert_tokens};
+    
+    #[test]
+    fn asn() {
+        #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+        struct AsnTest(
+            Asn,
+
+            #[serde(
+                deserialize_with = "Asn::deserialize_from_u32",
+                serialize_with = "Asn::serialize_as_u32",
+            )]
+            Asn,
+
+            #[serde(
+                deserialize_with = "Asn::deserialize_from_str",
+                serialize_with = "Asn::serialize_as_str",
+            )]
+            Asn,
+        );
+
+        assert_tokens(
+            &AsnTest ( Asn(0), Asn(0), Asn(0) ),
+            &[
+                Token::TupleStruct { name: "AsnTest", len: 3 },
+                Token::NewtypeStruct { name: "Asn" }, Token::U32(0),
+                Token::U32(0),
+                Token::Str("AS0"),
+                Token::TupleStructEnd,
+            ]
+        );
+    }
+
+    #[test]
+    fn asn_any() {
+        #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+        struct AsnTest(
+            #[serde(deserialize_with = "Asn::deserialize_from_any")]
+            Asn,
+            #[serde(deserialize_with = "Asn::deserialize_from_any")]
+            Asn,
+            #[serde(deserialize_with = "Asn::deserialize_from_any")]
+            Asn,
+            #[serde(deserialize_with = "Asn::deserialize_from_any")]
+            Asn,
+            #[serde(deserialize_with = "Asn::deserialize_from_any")]
+            Asn,
+            #[serde(deserialize_with = "Asn::deserialize_from_any")]
+            Asn,
+        );
+
+        assert_de_tokens(
+            &AsnTest(Asn(0), Asn(0), Asn(0), Asn(0), Asn(0), Asn(0)),
+            &[
+                Token::TupleStruct { name: "AsnTest", len: 5 },
+                Token::U32(0),
+                Token::U64(0),
+                Token::I64(0),
+                Token::Str("0"),
+                Token::Str("AS0"),
+                Token::Str("As0"),
+                Token::TupleStructEnd,
+            ]
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn asn() {
+        assert_eq!(Asn::from_u32(1234), Asn(1234));
+        assert_eq!(Asn(1234).into_u32(), 1234);
+
+        assert_eq!(Asn::from(1234_u32), Asn(1234));
+        assert_eq!(u32::from(Asn(1234)), 1234_u32);
+
+        assert_eq!(format!("{}", Asn(1234)).as_str(), "AS1234");
+
+        assert_eq!("0".parse::<Asn>(), Ok(Asn(0)));
+        assert_eq!("AS1234".parse::<Asn>(), Ok(Asn(1234)));
+        assert_eq!("as1234".parse::<Asn>(), Ok(Asn(1234)));
+        assert_eq!("As1234".parse::<Asn>(), Ok(Asn(1234)));
+        assert_eq!("aS1234".parse::<Asn>(), Ok(Asn(1234)));
+        assert_eq!("1234".parse::<Asn>(), Ok(Asn(1234)));
+
+        assert_eq!("".parse::<Asn>(), Err(ParseAsnError));
+        assert_eq!("-1234".parse::<Asn>(), Err(ParseAsnError));
+        assert_eq!("4294967296".parse::<Asn>(), Err(ParseAsnError));
+    }
+
+
+    //--- SmallAsnSet
+
+    // Checks that our set operation does the same as the same on
+    // HashSet<Asn>.
+    macro_rules! check_set_fn {
+        ( $fn:ident, $left:expr, $right:expr $(,)? ) => {{
+            let left = Vec::from_iter($left.into_iter().map(Asn::from_u32));
+            let right = Vec::from_iter($right.into_iter().map(Asn::from_u32));
+
+            let set_fn = {
+                let left = SmallAsnSet::from_iter(
+                    left.clone().into_iter()
+                );
+                let right = SmallAsnSet::from_iter(
+                    right.clone().into_iter()
+                );
+                left.$fn(&right).collect::<HashSet<Asn>>()
+            };
+            let hash_fn: HashSet<Asn> = {
+                let left: HashSet<Asn> = HashSet::from_iter(
+                    left.clone().into_iter()
+                );
+                let right: HashSet<Asn> = HashSet::from_iter(
+                    right.clone().into_iter()
+                );
+                left.$fn(&right).cloned().collect()
+            };
+            assert_eq!(set_fn, hash_fn);
+        }}
+    }
+
+    macro_rules! check_all_set_fns {
+        ( $left:expr, $right:expr $(,)? ) => {{
+            check_set_fn!(difference, $left, $right);
+            check_set_fn!(symmetric_difference, $left, $right);
+            check_set_fn!(intersection, $left, $right);
+            check_set_fn!(union, $left, $right);
+        }}
+    }
+
+    #[test]
+    fn small_set_operations() {
+        check_all_set_fns!([0, 1, 2, 3], [0, 1, 2, 3]);
+        check_all_set_fns!([0, 1, 2], [0, 1, 2, 3]);
+        check_all_set_fns!([0, 1, 2, 3], [0, 1, 2]);
+        check_all_set_fns!([0, 1, 2, 3], [0, 1, 2]);
+        check_all_set_fns!([], []);
+        check_all_set_fns!([1, 2, 3], []);
+        check_all_set_fns!([], [1, 2, 3]);
+    }
+
+    #[test]
+    fn path_segment() {
+        assert!(SegmentType::try_from(1_u8).is_ok());
+        assert_eq!(
+            SegmentType::try_from(1_u8).unwrap(),
+            SegmentType::Set
+        );
+        assert_eq!(
+            SegmentType::try_from(2_u8).unwrap(),
+            SegmentType::Sequence
+        );
+        assert_eq!(
+            SegmentType::try_from(3_u8).unwrap(),
+            SegmentType::ConfedSequence
+        );
+        assert_eq!(
+            SegmentType::try_from(4_u8).unwrap(),
+            SegmentType::ConfedSet
+        );
+        for i in 5_u8..=255 {
+            assert!(SegmentType::try_from(i).is_err());
+        }
+
+        assert_eq!(u8::from(SegmentType::Set), 1);
+        assert_eq!(u8::from(SegmentType::Sequence), 2);
+        assert_eq!(u8::from(SegmentType::ConfedSequence), 3);
+        assert_eq!(u8::from(SegmentType::ConfedSet), 4);
+
+        assert_eq!(
+            format!("{}", SegmentType::Set).as_str(),
+            "AS_SET"
+        );
+        assert_eq!(
+            format!("{}", SegmentType::Sequence).as_str(),
+            "AS_SEQUENCE"
+        );
+        assert_eq!(
+            format!("{}", SegmentType::ConfedSequence).as_str(),
+            "AS_CONFED_SEQUENCE"
+        );
+        assert_eq!(
+            format!("{}", SegmentType::ConfedSet).as_str(),
+            "AS_CONFED_SET"
+        );
+    }
+
+    #[test]
+    fn sentinel() {
+        let mut snt = encode_sentinel(SegmentType::Set, 0);
+        for i in 0_u8..=255 {
+            assert_eq!(
+                decode_sentinel(encode_sentinel(SegmentType::Set, i)),
+                (SegmentType::Set, i)
+            );
+            update_sentinel_len(&mut snt, i);
+            assert_eq!(encode_sentinel(SegmentType::Set, i), snt);
+        }
+    }
+
+    #[test]
+    fn as_path_builder() {
+        let default_pb = AsPathBuilder::default();
+        let mut pb = AsPathBuilder::new();
+        assert_eq!(default_pb, pb);
+        assert_eq!(pb.segments[0], encode_sentinel(SegmentType::Sequence, 0));
+        assert_eq!(pb.segments.len(), 1);
+        assert_eq!(pb.curr_start, 0);
+
+        pb.start(SegmentType::ConfedSet);
+        assert_eq!(
+            pb.segments[0],
+            encode_sentinel(SegmentType::ConfedSet, 0)
+        );
+        assert_eq!(pb.segments.len(), 1);
+        assert_eq!(pb.segment_len(), 0);
+        assert_eq!(pb.curr_start, 0);
+
+        assert!(pb.push(Asn(1234)).is_ok());
+        assert_eq!(pb.segments.len(), 2);
+        assert_eq!(pb.segment_len(), 1);
+        assert_eq!(pb.curr_start, 0);
+
+        // add another, new segment. start() should close the first one
+        pb.start(SegmentType::Sequence);
+        assert_eq!(pb.segments[2], encode_sentinel(SegmentType::Sequence, 0));
+        assert_eq!(pb.segments.len(), 3);
+        assert_eq!(pb.segment_len(), 0);
+        assert_eq!(pb.curr_start, 2);
+
+        assert!(pb.push(Asn(2000)).is_ok());
+        assert!(pb.push(Asn(3000)).is_ok());
+
+        assert_eq!(pb.segments.len(), 5);
+        assert_eq!(pb.segment_len(), 2);
+        assert_eq!(pb.curr_start, 2);
+
+        assert!(pb
+            .extend_from_slice(&[Asn(4000), Asn(5000), Asn(6000)])
+            .is_ok()
+        );
+        assert_eq!(pb.segments.len(), 8);
+        assert_eq!(pb.segment_len(), 5);
+        assert_eq!(pb.curr_start, 2);
+
+        let asp: AsPath<Vec<Asn>> = pb.finalize();
+
+        assert_eq!(
+            decode_sentinel(asp.segments[0]),
+            (SegmentType::ConfedSet, 1)
+        );
+        assert_eq!(
+            decode_sentinel(asp.segments[2]),
+            (SegmentType::Sequence, 2 + 3)
+        );
+
+        let ps = asp.iter().collect::<Vec<PathSegment<'_>>>();
+
+        assert_eq!(ps.len(), 2);
+        assert_eq!(ps[0].segment_type(), SegmentType::ConfedSet);
+        assert_eq!(ps[0].elements(), &[Asn(1234)]);
+        assert_eq!(ps[1].segment_type(), SegmentType::Sequence);
+        assert_eq!(
+            ps[1].elements(),
+            &[Asn(2000), Asn(3000), Asn(4000), Asn(5000), Asn(6000)]
+        );
+        assert_eq!(
+            format!("{}", ps[1]).as_str(),
+            "AS_SEQUENCE(AS2000, AS3000, AS4000, AS5000, AS6000)"
+        );
+
+        assert_eq!(
+            format!("{}", asp).as_str(),
+            "AS_CONFED_SET(AS1234), AS_SEQUENCE(AS2000, AS3000, AS4000, AS5000, AS6000)"
+        );
+
+        let mut pb2 = AsPathBuilder::new();
+        assert!(pb2.extend_from_slice(&[Asn(1234); 255]).is_ok());
+        assert!(pb2.push(Asn(1235)).is_err());
+        assert!(pb2.extend_from_slice(&[Asn(1235)]).is_err());
+
+        pb2.start(SegmentType::Set);
+        assert!(pb2.extend_from_slice(&[Asn(2345); 255]).is_ok());
+
+        let asp2: AsPath<Vec<Asn>> = pb2.finalize();
+        let mut segment_cnt = 0;
+        let mut as_cnt = 0;
+        for ps in asp2.into_iter() {
+            segment_cnt += 1;
+            for _asn in ps.elements() {
+                as_cnt += 1;
+            }
+        }
+        assert_eq!(segment_cnt, 2);
+        assert_eq!(as_cnt, 255 + 255);
+    }
+}

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -1,0 +1,3 @@
+
+pub mod addr;
+pub mod asn;

--- a/src/rtr/payload.rs
+++ b/src/rtr/payload.rs
@@ -10,9 +10,9 @@
 use std::{fmt, hash};
 use std::cmp::Ordering;
 use std::time::Duration;
-use routecore::addr::MaxLenPrefix;
-use routecore::asn::Asn;
-use routecore::bgpsec::KeyIdentifier;
+use crate::crypto::keys::KeyIdentifier;
+use crate::resources::addr::MaxLenPrefix;
+use crate::resources::asn::Asn;
 use super::pdu::{ProviderAsns, RouterKeyInfo};
 
 

--- a/src/rtr/pdu.rs
+++ b/src/rtr/pdu.rs
@@ -11,9 +11,9 @@ use std::convert::TryFrom;
 use std::marker::Unpin;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use bytes::Bytes;
-use routecore::addr::{MaxLenPrefix, Prefix};
-use routecore::asn::Asn;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use crate::resources::addr::{MaxLenPrefix, Prefix};
+use crate::resources::asn::Asn;
 use super::payload;
 use super::state::{Serial, State};
 

--- a/src/slurm.rs
+++ b/src/slurm.rs
@@ -12,10 +12,10 @@ use std::{borrow, error, fmt, io, ops};
 use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;
 use bytes::Bytes;
-use routecore::addr::{MaxLenPrefix, Prefix};
-use routecore::bgpsec::KeyIdentifier;
-use routecore::asn::Asn;
 use serde::{Deserialize, Serialize};
+use crate::crypto::keys::KeyIdentifier;
+use crate::resources::addr::{MaxLenPrefix, Prefix};
+use crate::resources::asn::Asn;
 use crate::rtr::payload as rtr;
 use crate::rtr::pdu::{RouterKeyInfo, KeyInfoError};
 

--- a/src/util/hex.rs
+++ b/src/util/hex.rs
@@ -1,0 +1,30 @@
+//! Converting from and to hex strings.
+#![allow(dead_code)]
+
+use std::str;
+
+
+/// Encodes a octet sequence as a hex string.
+///
+/// The function uses `dest` as the buffer for encoding which therefore must
+/// be exactly twice the length of `src`. It returns a reference to this
+/// buffer as a `&str`.
+///
+/// # Panics
+///
+/// The function panics if `dest` is shorter than twice the length of `src`.
+pub fn encode<'a>(src: &[u8], dest: &'a mut [u8]) -> &'a str {
+    let dest = &mut dest[..src.len() * 2];
+    for (s, d) in src.iter().zip(dest.chunks_mut(2)) {
+        d[0] = DIGITS[usize::from(s >> 4)];
+        d[1] = DIGITS[usize::from(s & 0x0F)];
+    }
+    unsafe { str::from_utf8_unchecked(dest) }
+}
+
+pub fn encode_u8(ch: u8) -> [u8; 2] {
+    [DIGITS[usize::from(ch >> 4)], DIGITS[usize::from(ch & 0x0F)]]
+}
+
+const DIGITS: &[u8] = b"0123456789ABCDEF";
+

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub mod hex;


### PR DESCRIPTION
This PR drops _routecore_ as a dependency and includes all the code from that crate we need for RPKI.

Having a shared dependency between the RPKI and BGP projects was a bit premature and the overlap is relatively small. Keeping things separate removes some administrative burden on the BGP projects during their early stages, so this seems the right move. We can always reconsider later.

The PR moves what used to be `routecore::{addr, asn}` to `crate::resources::asn` and`routecore::bgpsec::KeyIdentifier` to `crate::crypto::keys::KeyIdentifier` (where it was re-exported already previously).