### PR TITLE
Add `base64::Slurm::encode_writer`.

### DIFF
--- a/src/util/base64.rs
+++ b/src/util/base64.rs
@@ -135,6 +135,12 @@ impl Slurm {
         Self::ENGINE.encode(data)
     }
 
+    pub fn encode_writer(
+        self, writer: impl io::Write
+    ) -> impl io::Write {
+        base64::write::EncoderWriter::new(writer, &Self::ENGINE)
+    }
+
     pub fn display(self, data: &[u8]) -> impl fmt::Display + '_ {
         base64::display::Base64Display::new(data, &Self::ENGINE)
     }


### PR DESCRIPTION
This PR adds a `encode_writer` method to `util::base64::Slurm`.