### PR TITLE
Upgrade bcder to 0.7.3.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 arbitrary       = { version = "1", optional = true, features = ["derive"] }
 base64          = "0.21"
-bcder           = { version = "0.7", optional = true }
+bcder           = { version = "0.7.3", optional = true }
 bytes           = "1.0"
 futures-util    = { version = "0.3", optional = true }
 chrono          = { version = "0.4.10", features = [ "serde" ] }


### PR DESCRIPTION
This PR upgrades the _bcder_ dependency to at least 0.7.3. This avoids the decoding issues described in CVE-2023-39914.