### PR TITLE
Upgrade dependencies: ring and quick-xml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,13 +26,13 @@ chrono          = { version = "0.4.10", features = [ "serde" ] }
 log             = "0.4.7"
 openssl         = { version = "0.10.23", optional = true }
 quick-xml       = { version = "0.29.0", optional = true }
-ring            = { version = "0.16.11", optional = true }
+ring            = { version = "0.17.6", optional = true }
 serde           = { version = "1.0.103", optional = true, features = [ "derive" ] }
 serde_json      = { version = "1.0.40", optional = true }
 tokio           = { version = "1.0", optional = true, features = ["io-util",  "net", "rt", "sync", "time"] }
 tokio-stream    = { version = "0.1", optional = true }
 uuid            = "1.1"
-untrusted       = { version = "0.7.0", optional = true }
+untrusted       = { version = "0.9", optional = true }
 
 [dev-dependencies]
 serde_json      = "1.0.40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ futures-util    = { version = "0.3", optional = true }
 chrono          = { version = "0.4.10", features = [ "serde" ] }
 log             = "0.4.7"
 openssl         = { version = "0.10.23", optional = true }
-quick-xml       = { version = "0.29.0", optional = true }
+quick-xml       = { version = "0.31.0", optional = true }
 ring            = { version = "0.17.6", optional = true }
 serde           = { version = "1.0.103", optional = true, features = [ "derive" ] }
 serde_json      = { version = "1.0.40", optional = true }

--- a/src/repository/x509.rs
+++ b/src/repository/x509.rs
@@ -1351,12 +1351,10 @@ mod test {
 
     #[test]
     fn next_year() {
-        let now = DateTime::parse_from_rfc3339(
-            "2014-10-21T16:39:57-00:00"
+        let now = Utc.with_ymd_and_hms(
+            2014, 10, 21, 16, 39, 57
         ).unwrap();
-        let future = Time::years_from_date(
-            1, DateTime::from_utc(now.naive_utc(), Utc)
-        );
+        let future = Time::years_from_date(1, now);
 
         assert_eq!(future.year(), 2015);
         assert_eq!(future.month(), 10);
@@ -1368,12 +1366,10 @@ mod test {
 
     #[test]
     fn next_year_from_leap() {
-        let now = DateTime::parse_from_rfc3339(
-            "2020-02-29T16:39:57-00:00"
+        let now = Utc.with_ymd_and_hms(
+            2020, 2, 29, 16, 39, 57
         ).unwrap();
-        let future = Time::years_from_date(
-            10, DateTime::from_utc(now.naive_utc(), Utc)
-        );
+        let future = Time::years_from_date(10, now);
 
         assert_eq!(future.year(), 2030);
         assert_eq!(future.month(), 2);


### PR DESCRIPTION
This PR upgrades the dependencies to new breaking versions. In particular, these are the _ring_ and _quick-xml_ crates.

Fixes #277.

This is a breaking change.