### PR TITLE
Let RTR server not support v2 just yet.

### DIFF
--- a/src/rtr/server.rs
+++ b/src/rtr/server.rs
@@ -25,7 +25,11 @@ use super::state::State;
 /// The maximum protocol version we support.
 ///
 /// We support all protocol versions from 0 up to and including this value.
-const MAX_VERSION: u8 = 2;
+///
+/// While the server technically supports version 2 as well, the format of the
+/// ASPA PDU has not yet been agreed upon. Rather than possibly deploying
+/// broken servers, we only announce support for version 0 or 1 for now.
+const MAX_VERSION: u8 = 1;
 
 //============ Traits ========================================================
 


### PR DESCRIPTION
This PR limits the protocol version supported by the RTR server to 1 or less.

While we technically support version 2, the ASPA PDU format has not yet been agreed upon and may still change. So rather than have people deploy potentially broken servers, we disable the version.