### PR TITLE
Improve rtr client version negotiation.

### DIFF
--- a/src/rtr/server.rs
+++ b/src/rtr/server.rs
@@ -25,7 +25,11 @@ use super::state::State;
 /// The maximum protocol version we support.
 ///
 /// We support all protocol versions from 0 up to and including this value.
-const MAX_VERSION: u8 = 2;
+///
+/// While the server technically supports version 2 as well, the format of the
+/// ASPA PDU has not yet been agreed upon. Rather than possibly deploying
+/// broken servers, we only announce support for version 0 or 1 for now.
+const MAX_VERSION: u8 = 1;
 
 //============ Traits ========================================================
 


### PR DESCRIPTION
This PR improves (well, fixes) the protocol version negotiation of the RTR client.

Previously it just accepted whatever version the server proposed. Now it requests a pre-defined maximum version and rejects any response with a version greater than it.