### PR TITLE
Upgrade to chrono 0.4.35.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ arbitrary       = { version = "1", optional = true, features = ["derive"] }
 base64          = "0.21"
 bcder           = { version = "0.7.3", optional = true }
 bytes           = "1.0"
+chrono          = { version = "0.4.35", features = [ "serde" ] }
 futures-util    = { version = "0.3", optional = true }
-chrono          = { version = "0.4.10", features = [ "serde" ] }
 log             = "0.4.7"
 openssl         = { version = "0.10.23", optional = true }
 quick-xml       = { version = "0.31.0", optional = true }

--- a/src/repository/x509.rs
+++ b/src/repository/x509.rs
@@ -13,7 +13,7 @@ use bcder::decode::{DecodeError, ContentError, IntoSource, Source};
 use bcder::encode::PrimitiveContent;
 use bcder::string::{PrintableString, Utf8String};
 use chrono::{
-    Datelike, DateTime, Duration, LocalResult, Timelike, TimeZone, Utc
+    Datelike, DateTime, LocalResult, TimeDelta, Timelike, TimeZone, Utc
 };
 use crate::oid;
 use crate::crypto::{
@@ -673,19 +673,19 @@ impl Time {
     }
 
     pub fn five_minutes_ago() -> Self {
-        Self::now() - Duration::minutes(5)
+        Self::now() - TimeDelta::try_minutes(5).unwrap()
     }
 
     pub fn five_minutes_from_now() -> Self {
-        Self::now() + Duration::minutes(5)
+        Self::now() + TimeDelta::try_minutes(5).unwrap()
     }
 
     pub fn tomorrow() -> Self {
-        Self::now() + Duration::days(1)
+        Self::now() + TimeDelta::try_days(1).unwrap()
     }
 
     pub fn next_week() -> Self {
-        Self::now() + Duration::weeks(1)
+        Self::now() + TimeDelta::try_weeks(1).unwrap()
     }
 
     pub fn next_year() -> Self {
@@ -946,10 +946,10 @@ impl FromStr for Time {
 
 //--- Add
 
-impl ops::Add<Duration> for Time {
+impl ops::Add<TimeDelta> for Time {
     type Output = Self;
 
-    fn add(self, duration: Duration) -> Self::Output {
+    fn add(self, duration: TimeDelta) -> Self::Output {
         Self::new(self.0 + duration)
     }
 }
@@ -957,10 +957,10 @@ impl ops::Add<Duration> for Time {
 
 //--- Sub
 
-impl ops::Sub<Duration> for Time {
+impl ops::Sub<TimeDelta> for Time {
     type Output = Self;
 
-    fn sub(self, duration: Duration) -> Self::Output {
+    fn sub(self, duration: TimeDelta) -> Self::Output {
         Self::new(self.0 - duration)
     }
 }
@@ -1065,7 +1065,7 @@ impl Validity {
         Validity { not_before, not_after }
     }
 
-    pub fn from_duration(duration: Duration) -> Self {
+    pub fn from_duration(duration: TimeDelta) -> Self {
         let not_before = Time::now();
         let not_after = Time::new(Utc::now() + duration);
         if not_before < not_after {
@@ -1077,7 +1077,7 @@ impl Validity {
     }
 
     pub fn from_secs(secs: i64) -> Self {
-        Self::from_duration(Duration::seconds(secs))
+        Self::from_duration(TimeDelta::try_seconds(secs).unwrap())
     }
 
     pub fn not_before(self) -> Time {


### PR DESCRIPTION
This PR upgrade the dependency on chrono 0.4.35. This mostly means `chrono::Duration` is now `chrono::TimeDelta` (to distinguish it from std’s `Duration` type).  In order to avoid breaking changes, this PR does not rename `Validity::from_duration`.