### PR TITLE
Update MSRV to 1.64.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.63.0, stable, beta, nightly]
+        rust: [1.64.0, stable, beta, nightly]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rpki"
 version = "0.18.2-dev"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.64"
 authors = ["NLnet Labs <rpki-team@nlnetlabs.nl>"]
 description = "A library for validating and creating RPKI data."
 documentation = "https://docs.rs/rpki/"


### PR DESCRIPTION
This PR updates the reported minimal supported Rust version to 1.64.

This was already required since some code uses the `await` keyword. So it can probably be done safely without a breaking change.