### PR TITLE
Add a check for same-origin to uri::Https and rrdp::NotificationFile.

### DIFF
--- a/src/rrdp.rs
+++ b/src/rrdp.rs
@@ -1810,5 +1810,10 @@ mod test {
             "https://foo.bar/1/2/3",
             ["https://foo.bar/", "https://foo.bar/4", "https://foo.bar/7/8"],
         ));
+
+        assert!(!check(
+            "https://foo.bar/1/2/3",
+            ["https://foo.bar/", "https://foo.local/4"],
+        ));
     }
 }

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -651,6 +651,11 @@ impl Https {
             Some(res)
         }
     }
+
+    /// Returns whether the two URIs have the same authority.
+    pub fn eq_authority(&self, other: &Self) -> bool {
+        self.authority().eq_ignore_ascii_case(other.authority())
+    }
 }
 
 


### PR DESCRIPTION
This PR adds a check for the same origin (i.e., authority part) to `uri::Https` and all URIs in the RRDP notification file.