### PR TITLE
Introduce `rrdp::NotificationFile::parse_limited`.

### DIFF
--- a/src/rrdp.rs
+++ b/src/rrdp.rs
@@ -107,6 +107,8 @@ impl NotificationFile {
     /// Returns the list of available delta updates.
     ///
     /// Deltas can be processed using the [`ProcessDelta`] trait.
+    ///
+    /// If `delta_status` returns an error, this list will be empty.
     pub fn deltas(&self) -> &[DeltaInfo] {
         match self.deltas {
             Ok(ref deltas) => deltas.as_slice(),


### PR DESCRIPTION
This PR adds a new function `rrdp::NotificationFile::parse_limited` that allows limiting the number of delta items accepted. If there are more items, the list will be cut back to empty and a new method `delta_status` will report an error.