### PR TITLE
Correctly encode a CRL with empty revokedCertificates.

### DIFF
--- a/src/repository/crl.rs
+++ b/src/repository/crl.rs
@@ -563,7 +563,9 @@ impl RevokedCertificates {
 
     /// Returns a value encoder for a reference to the value.
     pub fn encode_ref(&self) -> impl encode::Values + '_ {
-        encode::sequence(&self.0)
+        (!self.0.is_empty()).then(|| {
+            encode::sequence(&self.0)
+        })
     }
 
     /// Create a value from an iterator over CRL entries.
@@ -827,6 +829,18 @@ mod signer_test {
             Time::now(),
             Time::tomorrow(),
             vec![CrlEntry::new(12u64.into(), Time::now())],
+            pubkey.key_identifier(),
+            12u64.into()
+        );
+        let crl = crl.into_crl(&signer, &key).unwrap().to_captured();
+        let _crl = Crl::decode(crl.as_slice()).unwrap();
+
+        let crl = TbsCertList::new(
+            Default::default(),
+            pubkey.to_subject_name(),
+            Time::now(),
+            Time::tomorrow(),
+            vec![],
             pubkey.key_identifier(),
             12u64.into()
         );


### PR DESCRIPTION
This PR fixes the encoding of CRLs by leaving out the _revokedCertificates_ element entirely if it is empty as required by section 5.1.2.6 of RFC 5280.

There is no test whether it is actually left out since I can’t quite think of a way to do that. I have, however, manually verified the encoding and there are now tests for both cases that check that we ourselves accept the result.