### PR TITLE
Add Ipv4Block and Ipv6Block.

### DIFF
--- a/src/repository/resources/ipres.rs
+++ b/src/repository/resources/ipres.rs
@@ -1830,7 +1830,7 @@ impl fmt::Display for Ipv6Block {
 /// Contains IPv4 resources. This type is a thin wrapper around the underlying
 /// [`IpBlocks`] type intended to help with serializing/deserializing and
 /// formatting using IPv4 syntax.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Ipv4Blocks(IpBlocks);
 
 impl Ipv4Blocks {
@@ -1927,7 +1927,7 @@ impl std::ops::Deref for Ipv4Blocks {
 /// Contains IPv6 resources. This type is a thin wrapper around the underlying
 /// [`IpBlocks`] type intended to help with serializing/deserializing and
 /// formatting using IPv6 syntax.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Ipv6Blocks(IpBlocks);
 
 impl Ipv6Blocks {

--- a/src/repository/resources/ipres.rs
+++ b/src/repository/resources/ipres.rs
@@ -1709,6 +1709,110 @@ impl AddressFamily {
 }
 
 
+//------------ Ipv4Block -----------------------------------------------------
+
+/// Contains an IPv4 address block.
+///
+/// This type is a thin wrapper around [`IpBlock`] ensuring that this is an
+/// IPv4 address block.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Ipv4Block(IpBlock);
+
+impl Ipv4Block {
+    /// Creates a new block covering all addresses.
+    pub fn all() -> Self {
+        Self(IpBlock::all())
+    }
+
+    /// Returns whether the block is prefix with address length zero.
+    pub fn is_slash_zero(&self) -> bool {
+        self.0.is_slash_zero()
+    }
+
+    /// The smallest address of the block.
+    pub fn min(&self) -> Ipv4Addr {
+        self.0.min().into()
+    }
+
+    /// The largest address of the block.
+    pub fn max(&self) -> Ipv4Addr {
+        self.0.max().into()
+    }
+}
+
+
+//--- FromStr
+
+impl str::FromStr for Ipv4Block {
+    type Err = FromStrError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(IpBlock::from_v4_str(s)?))
+    }
+}
+
+
+//--- Display
+
+impl fmt::Display for Ipv4Block {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt_v4(f)
+    }
+}
+
+
+//------------ Ipv6Block -----------------------------------------------------
+
+/// Contains an IPv6 address block.
+///
+/// This type is a thin wrapper around [`IpBlock`] ensuring that this is an
+/// IPv6 address block.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Ipv6Block(IpBlock);
+
+impl Ipv6Block {
+    /// Creates a new block covering all addresses.
+    pub fn all() -> Self {
+        Self(IpBlock::all())
+    }
+
+    /// Returns whether the block is prefix with address length zero.
+    pub fn is_slash_zero(&self) -> bool {
+        self.0.is_slash_zero()
+    }
+
+    /// The smallest address of the block.
+    pub fn min(&self) -> Ipv6Addr {
+        self.0.min().into()
+    }
+
+    /// The largest address of the block.
+    pub fn max(&self) -> Ipv6Addr {
+        self.0.max().into()
+    }
+}
+
+
+//--- FromStr
+
+impl str::FromStr for Ipv6Block {
+    type Err = FromStrError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(IpBlock::from_v6_str(s)?))
+    }
+}
+
+
+//--- Display
+
+impl fmt::Display for Ipv6Block {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt_v6(f)
+    }
+}
+
+
 //------------ Ipv4Blocks ----------------------------------------------------
 
 /// Contains IPv4 resources. This type is a thin wrapper around the underlying

--- a/src/repository/resources/ipres.rs
+++ b/src/repository/resources/ipres.rs
@@ -1741,7 +1741,13 @@ impl Ipv4Block {
 }
 
 
-//--- FromStr
+//--- From and FromStr
+
+impl From<Ipv4Block> for IpBlock {
+    fn from(src: Ipv4Block) -> IpBlock {
+        src.0
+    }
+}
 
 impl str::FromStr for Ipv4Block {
     type Err = FromStrError;
@@ -1793,7 +1799,13 @@ impl Ipv6Block {
 }
 
 
-//--- FromStr
+//--- From and FromStr
+
+impl From<Ipv6Block> for IpBlock {
+    fn from(src: Ipv6Block) -> IpBlock {
+        src.0
+    }
+}
 
 impl str::FromStr for Ipv6Block {
     type Err = FromStrError;
@@ -1844,7 +1856,7 @@ impl fmt::Display for Ipv4Blocks {
     }
 }
 
-//--- FromStr
+//--- FromStr and FromIterator
 
 impl FromStr for Ipv4Blocks {
     type Err = FromStrError;
@@ -1865,6 +1877,12 @@ impl FromStr for Ipv4Blocks {
         }
 
         Ok(Ipv4Blocks(builder.finalize()))
+    }
+}
+
+impl FromIterator<Ipv4Block> for Ipv4Blocks {
+    fn from_iter<I: IntoIterator<Item = Ipv4Block>>(iter: I) -> Self {
+        Self(IpBlocks::from_iter(iter.into_iter().map(Into::into)))
     }
 }
 
@@ -1935,7 +1953,7 @@ impl fmt::Display for Ipv6Blocks {
     }
 }
 
-//--- FromStr
+//--- FromStr and FromIterator
 
 impl FromStr for Ipv6Blocks {
     type Err = FromStrError;
@@ -1956,6 +1974,12 @@ impl FromStr for Ipv6Blocks {
         }
 
         Ok(Ipv6Blocks(builder.finalize()))
+    }
+}
+
+impl FromIterator<Ipv6Block> for Ipv6Blocks {
+    fn from_iter<I: IntoIterator<Item = Ipv6Block>>(iter: I) -> Self {
+        Self(IpBlocks::from_iter(iter.into_iter().map(Into::into)))
     }
 }
 

--- a/src/repository/resources/mod.rs
+++ b/src/repository/resources/mod.rs
@@ -20,10 +20,10 @@ pub use self::asres::{
 };
 pub use self::choice::ResourcesChoice;
 pub use self::ipres::{
-    Addr, AddressFamily, InheritedIpResources, IpBlock, IpBlocks, Ipv4Blocks,
-    Ipv6Blocks, IpBlocksBuilder, IpBlocksForFamily, IpResources,
-    IpResourcesBuilder, OverclaimedIpResources, OverclaimedIpv4Resources,
-    OverclaimedIpv6Resources, Prefix
+    Addr, AddressFamily, InheritedIpResources, IpBlock, IpBlocks, Ipv4Block,
+    Ipv4Blocks, Ipv6Block, Ipv6Blocks, IpBlocksBuilder, IpBlocksForFamily,
+    IpResources, IpResourcesBuilder, OverclaimedIpResources,
+    OverclaimedIpv4Resources, OverclaimedIpv6Resources, Prefix
 };
 pub use self::set::{
     ResourceDiff, ResourceSet


### PR DESCRIPTION
This PR adds new types `Ipv4Block` and `Ipv6Block` that wrap an `IpBlock` and enforce it to be of the correct address family. In addition it adds `FromIterator` impls to `Ipv4Blocks` and `Ipv6Blocks`.