### PR TITLE
Increase minimum Rust version to 1.67.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.64.0, stable, beta, nightly]
+        rust: [1.67.0, stable, beta, nightly]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rpki"
 version = "0.18.4"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.67"
 authors = ["NLnet Labs <rpki-team@nlnetlabs.nl>"]
 description = "A library for validating and creating RPKI data."
 documentation = "https://docs.rs/rpki/"


### PR DESCRIPTION
This is required by the transitive `cc` dependency.