### PR TITLE
Do not allow backslashes in idexchange handles.

### DIFF
--- a/src/ca/idexchange.rs
+++ b/src/ca/idexchange.rs
@@ -141,7 +141,7 @@ impl<T> Handle<T> {
 
     fn verify_name(s: &str) -> Result<(), InvalidHandle> {
         if s.bytes()
-            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'/' || b == b'\\')
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'/')
             && !s.is_empty()
             && s.len() < 256
         {


### PR DESCRIPTION
This PR changes the `ca::idexchange::Handle` to not allow backslashes in its character set.

The definition of a handle in appendix A of RFC 8183 reads:

```
handle  = xsd:string { maxLength="255" pattern="[\-_A-Za-z0-9/]*" }
```

which I read as not allowing backslashes (as the backslash escapes the hyphen).