### PR TITLE
Various documentation fixes

### DIFF
--- a/src/ca/idexchange.rs
+++ b/src/ca/idexchange.rs
@@ -482,7 +482,7 @@ impl ChildRequest {
         writer.done()
     }
 
-    /// Writes the ChildRequest's XML representation to a new Vec<u8>.
+    /// Writes the ChildRequest's XML representation to a new `Vec<u8>`.
     pub fn to_xml_vec(&self) -> Vec<u8> {
         let mut vec = vec![];
         self.write_xml(&mut vec).unwrap(); // safe
@@ -730,7 +730,7 @@ impl ParentResponse {
         validate_idcert_at(&self.id_cert, when)
     }
 
-    /// Writes the ParentResponse's XML representation to a new Vec<u8>.
+    /// Writes the ParentResponse's XML representation to a new `Vec<u8>`.
     pub fn to_xml_vec(&self) -> Vec<u8> {
         let mut vec = vec![];
         self.write_xml(&mut vec).unwrap(); // safe
@@ -756,12 +756,12 @@ impl fmt::Display for ParentResponse {
 
 //------------ PublisherRequest ----------------------------------------------
 
-/// Type representing a <publisher_request/>
+/// Type representing a `<publisher_request/>`
 ///
 /// This is the XML message with identity information that a CA sends to a
 /// Publication Server.
 ///
-/// For more info, see: https://tools.ietf.org/html/rfc8183#section-5.2.3
+/// For more info, see: <https://tools.ietf.org/html/rfc8183#section-5.2.3>
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PublisherRequest {
     /// The self-signed IdCert containing the publisher's public key.
@@ -912,7 +912,7 @@ impl PublisherRequest {
         writer.done()
     }
 
-    /// Writes the PublisherRequest's XML representation to a new Vec<u8>.
+    /// Writes the PublisherRequest's XML representation to a new `Vec<u8>`.
     pub fn to_xml_vec(&self) -> Vec<u8> {
         let mut vec = vec![];
         self.write_xml(&mut vec).unwrap(); // safe
@@ -945,7 +945,7 @@ impl fmt::Display for PublisherRequest {
 /// This is the response sent to a CA by the publication server. It contains
 /// the details needed by the CA to send publication messages to the server.
 ///
-/// See https://tools.ietf.org/html/rfc8183#section-5.2.4
+/// See <https://tools.ietf.org/html/rfc8183#section-5.2.4>
 #[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq)]
 pub struct RepositoryResponse {
     /// The Publication Server Identity Certificate
@@ -1155,7 +1155,7 @@ impl RepositoryResponse {
         validate_idcert_at(&self.id_cert, when)
     }
 
-    /// Writes the RepositoryResponse's XML representation to a new Vec<u8>.
+    /// Writes the RepositoryResponse's XML representation to a new `Vec<u8>`.
     pub fn to_xml_vec(&self) -> Vec<u8> {
         let mut vec = vec![];
         self.write_xml(&mut vec).unwrap(); // safe

--- a/src/ca/provisioning.rs
+++ b/src/ca/provisioning.rs
@@ -270,7 +270,7 @@ impl Message {
 /// # Decoding from XML
 ///
 impl Message {
-    /// Parses an RFC 6492 <message />
+    /// Parses an RFC 6492 `<message />`
     pub fn decode<R: io::BufRead>(reader: R) -> Result<Self, Error> {
         let mut reader = xml::decode::Reader::new(reader);
 
@@ -375,7 +375,7 @@ impl Payload {
 /// # Encoding to XML
 ///
 impl Payload {
-    /// Value for the type attribute in the <message /> element.
+    /// Value for the type attribute in the `<message />` element.
     pub fn payload_type(&self) -> PayloadType {
         match self {
             Payload::List => PayloadType::List,
@@ -723,7 +723,7 @@ impl IssuanceResponse {
 /// Note that the IssuanceRequest will be rejected by the parent, if the limit
 /// exceeds the child's entitlements.
 ///
-/// See: https://tools.ietf.org/html/rfc6492#section-3.4.1
+/// See: <https://tools.ietf.org/html/rfc6492#section-3.4.1>
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RequestResourceLimit {
     #[serde(
@@ -998,7 +998,7 @@ impl From<&RevocationRequest> for RevocationResponse {
 
 //------------ KeyElement ----------------------------------------------------
 
-/// This type represents a <key /> element as used in both the Certificate
+/// This type represents a `<key />` element as used in both the Certificate
 /// Revocation Request and Response, sections 3.5.1 and 3.5.2 respectively,
 /// of RFC6492.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -1096,7 +1096,7 @@ impl fmt::Display for KeyElement {
 /// This structure is what is called the "Resource Class List Response"
 /// in section 3.3.2 of RFC6492.
 ///
-/// This response can have 0 or more <class /> elements containing the
+/// This response can have 0 or more `<class />` elements containing the
 /// entitlements for 0 or more corresponding resource classes.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ResourceClassListResponse {

--- a/src/ca/publication.rs
+++ b/src/ca/publication.rs
@@ -222,7 +222,7 @@ impl Message {
 /// # Decoding from XML
 /// 
 impl Message {
-    /// Parses an RFC 8181 <msg />
+    /// Parses an RFC 8181 `<msg />`
     pub fn decode<R: io::BufRead>(reader: R) -> Result<Self, Error> {
         let mut reader = xml::decode::Reader::new(reader);
 
@@ -539,7 +539,7 @@ impl QueryPdu {
 //------------ PublishDelta ------------------------------------------------
 
 /// This type represents a multi element query as described in
-/// https://tools.ietf.org/html/rfc8181#section-3.7
+/// <https://tools.ietf.org/html/rfc8181#section-3.7>
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PublishDelta(Vec<PublishDeltaElement>);
 
@@ -613,7 +613,7 @@ impl PublishDeltaElement {
 //------------ Publish -------------------------------------------------------
 
 /// Represents a publish element, that does not update any existing object.
-/// See: https://tools.ietf.org/html/rfc8181#section-3.1
+/// See: <https://tools.ietf.org/html/rfc8181#section-3.1>
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Publish {
     tag: Option<String>,
@@ -679,7 +679,7 @@ impl Publish {
 //------------ Update --------------------------------------------------------
 
 /// Represents a publish element, that replaces an existing object.
-/// See: https://tools.ietf.org/html/rfc8181#section-3.2
+/// See: <https://tools.ietf.org/html/rfc8181#section-3.2>
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Update {
     tag: Option<String>,
@@ -766,7 +766,7 @@ impl Update {
 //------------ Withdraw ------------------------------------------------------
 
 /// Represents a withdraw element that removes an object.
-/// See: https://tools.ietf.org/html/rfc8181#section-3.3
+/// See: <https://tools.ietf.org/html/rfc8181#section-3.3>
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Withdraw {
     tag: Option<String>,
@@ -1062,7 +1062,7 @@ impl ReplyPdu {
 //------------ ListReply -----------------------------------------------------
 
 /// This type represents the list reply as described in
-/// https://tools.ietf.org/html/rfc8181#section-2.3
+/// <https://tools.ietf.org/html/rfc8181#section-2.3>
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ListReply {
     elements: Vec<ListElement>,
@@ -1156,7 +1156,7 @@ impl ListElement {
 //------------ ErrorReply ----------------------------------------------------
 
 /// This type represents the error report as described in
-/// https://tools.ietf.org/html/rfc8181#section-3.5 and 3.6
+/// <https://tools.ietf.org/html/rfc8181#section-3.5> and 3.6
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct ErrorReply {
     errors: Vec<ReportError>,

--- a/src/ca/sigmsg.rs
+++ b/src/ca/sigmsg.rs
@@ -28,8 +28,11 @@ use super::idcert::IdCert;
 /// but similar structure.
 /// 
 /// Most important differences to watch out for:
-/// = This uses [`IdCert`] instead of [`Cert`] as the EE (no INRs needed)
-/// = This MUST include a CRL
+///  - This uses [`IdCert`] instead of [`Cert`] as the EE (no INRs needed)
+///  - This MUST include a CRL
+/// 
+/// [`Cert`]: crate::repository::cert::Cert 
+/// [`SignedObject`]: crate::repository::sigobj::SignedObject
 #[derive(Clone, Debug)]
 pub struct  SignedMessage {
     //--- From SignedData

--- a/src/crypto/digest.rs
+++ b/src/crypto/digest.rs
@@ -103,7 +103,7 @@ impl DigestAlgorithm {
 /// The functions and methods in this section allow decoding and encoding
 /// such values.
 ///
-/// [`SignatureAlgorithm`]: ../signature/struct.SignatureAlgorithm.html
+/// [`SignatureAlgorithm`]: super::SignatureAlgorithm
 /// [RFC 5754]: https://tools.ietf.org/html/rfc5754
 /// [RFC 7935]: https://tools.ietf.org/html/rfc7935
 impl DigestAlgorithm {
@@ -180,7 +180,7 @@ impl DigestAlgorithm {
         encode::sequence(oid::SHA256.encode())
     }
 
-    /// Provides an encoder for a indentifer as the sole value of a set.
+    /// Provides an encoder for a identifier as the sole value of a set.
     pub fn encode_set(self) -> impl encode::Values {
         encode::set(
             self.encode()

--- a/src/crypto/keys.rs
+++ b/src/crypto/keys.rs
@@ -78,7 +78,7 @@ impl PublicKeyFormat {
 /// defined by [RFC 4055] and the parameters must be present and NULL.
 /// When parsing, we generously also allow it to be absent altogether.
 ///
-/// For ECDSA keys, the object identifer needs to be `ecPublicKey` defined
+/// For ECDSA keys, the object identifier needs to be `ecPublicKey` defined
 /// in [RFC 5480] with the parameter being the object identifier `secp256r1`
 /// defined in the same RFC.
 ///
@@ -113,7 +113,7 @@ impl PublicKeyFormat{
         }
     }
 
-    /// Provides an encoder for the algorihm identifier.
+    /// Provides an encoder for the algorithm identifier.
     pub fn encode(self) -> impl encode::Values {
         match self {
             PublicKeyFormat::Rsa => {
@@ -177,7 +177,7 @@ impl PublicKey {
     /// Creates an RSA Public Key based on the supplied exponent and modulus.
     /// 
     /// See:
-    /// [RFC 4055]: https://tools.ietf.org/html/rfc4055
+    /// [RFC 4055]: <https://tools.ietf.org/html/rfc4055>
     /// 
     /// An RSA Public Key uses the following DER encoded structure inside its
     /// BitString component:
@@ -421,7 +421,7 @@ impl PrimitiveContent for PublicKeyCn {
 pub struct KeyIdentifier([u8; 20]);
 
 impl KeyIdentifier {
-    /// Returns an octet slice of the key identifer’s value.
+    /// Returns an octet slice of the key identifier’s value.
     pub fn as_slice(&self) -> &[u8] {
         self.0.as_ref()
     }
@@ -456,7 +456,7 @@ impl KeyIdentifier {
         cons.take_opt_value_if(bcder::Tag::OCTET_STRING, Self::from_content)
     }
 
-    /// Parses an encoded key identifer from encoded content.
+    /// Parses an encoded key identifier from encoded content.
     pub fn from_content<S: Source>(
         content: &mut decode::Content<S>
     ) -> Result<Self, DecodeError<S::Error>> {
@@ -481,7 +481,7 @@ impl KeyIdentifier {
         }
     }
 
-    /// Skips over an encoded key indentifier.
+    /// Skips over an encoded key identifier.
     pub fn skip_opt_in<S: Source>(
         cons: &mut decode::Constructed<S>
     ) -> Result<Option<()>, DecodeError<S::Error>> {

--- a/src/repository/cert.rs
+++ b/src/repository/cert.rs
@@ -12,8 +12,6 @@
 //!
 //! In addition, there are several types for the components of a certificate.
 //!
-//! [`Cert`]: struct.Cert.html
-//! [`ResourceCert`]: struct.ResourceCert.html
 //! [RFC 5280]: https://tools.ietf.org/html/rfc5280
 //! [RFC 6487]: https://tools.ietf.org/html/rfc5487
 
@@ -73,13 +71,12 @@ use super::x509::{
 /// further processing. In addition, various methods exist to access
 /// information contained in the certificate.
 ///
-/// [`ResourceCert`]: struct.ResourceCert.html
-/// [`decode`]: #method.decode
-/// [`take_from`]: #method.take_from
-/// [`from_constructed`]: #method.from_constructed
-/// [`validate_ca`]: #method.validate_ca
-/// [`validate_ee`]: #method.validate_ee
-/// [`validate_ta`]: #method.validate_ta
+/// [`decode`]: Cert::decode
+/// [`take_from`]: Cert::take_from
+/// [`from_constructed`]: Cert::from_constructed
+/// [`validate_ca`]: Cert::validate_ca
+/// [`validate_ee`]: Cert::validate_ee
+/// [`validate_ta`]: Cert::validate_ta
 #[derive(Clone, Debug)]
 pub struct Cert {
     /// The outer structure of the certificate.
@@ -256,7 +253,7 @@ impl Cert {
         self.verify_ee_at(issuer, strict, now).map_err(Into::into)
     }
 
-    /// Validates the certificate as a detached EE certficate.
+    /// Validates the certificate as a detached EE certificate.
     ///
     /// Such a certificate is used by signed objects that are not published
     /// through RPKI repositories.
@@ -384,7 +381,7 @@ impl Cert {
         // 4.8.1. Basic Constraints: Must not be present.
         if self.basic_ca.is_some(){
             return Err(InspectionError::new(
-                "Basic Contraints extension \
+                "Basic Constraints extension \
                  not allowed in end entity certificate"
             ))
         }
@@ -422,7 +419,7 @@ impl Cert {
         Ok(())
     }
 
-    /// Inspects the certificate as a detached EE certficate.
+    /// Inspects the certificate as a detached EE certificate.
     ///
     /// Checks that the certificate fulfills all formal requirements of such
     /// a certificate.
@@ -435,7 +432,7 @@ impl Cert {
         // 4.8.1. Basic Constraints: Must not be present.
         if self.basic_ca.is_some(){
             return Err(InspectionError::new(
-                "Basic Contraints extension \
+                "Basic Constraints extension \
                  not allowed in end entity certificate"
             ))
         }
@@ -506,7 +503,7 @@ impl Cert {
         // 4.8.1. Basic Constraints. Must not be present.
         if self.basic_ca.is_some(){
             return Err(InspectionError::new(
-                "Basic Contraints extension \
+                "Basic Constraints extension \
                  not allowed in end entity certificate"
             ))
         }
@@ -517,7 +514,7 @@ impl Cert {
             self.subject_public_key_info().key_identifier()
         {
             return Err(InspectionError::new(
-                "Subject Key Identifer extension doesn't match \
+                "Subject Key Identifier extension doesn't match \
                  the public key"
             ))
         }
@@ -588,7 +585,7 @@ impl Cert {
         }
         if self.as_resources().is_inherited() {
             return Err(InspectionError::new(
-                "inherited AS Resources in router certifiate"
+                "inherited AS Resources in router certificate"
             ))
         }
 

--- a/src/repository/crl.rs
+++ b/src/repository/crl.rs
@@ -10,10 +10,6 @@
 //!
 //! The RPKI CRL profile is defined in RFC 6487 based on the Internet RPIX
 //! profile defined in RFC 5280.
-//!
-//! [`Crl`]: struct.Crl.html
-//! [`CrlStore`]: struct.CrlStore.html
-
 use std::{fmt, ops};
 use std::collections::HashSet;
 use std::str::FromStr;
@@ -341,7 +337,7 @@ impl<C> TbsCertList<C> {
         &self.authority_key_id
     }
 
-    /// Sets the authority key identifer.
+    /// Sets the authority key identifier.
     pub fn set_authority_key_identifier(&mut self, id: KeyIdentifier) {
         self.authority_key_id = id
     }
@@ -627,7 +623,7 @@ impl CrlEntry {
         cons.take_sequence(Self::from_constructed)
     }
 
-    /// Takes an optional CRL entry from the beginning of a contructed value.
+    /// Takes an optional CRL entry from the beginning of a constructed value.
     pub fn take_opt_from<S: decode::Source>(
         cons: &mut decode::Constructed<S>
     ) -> Result<Option<Self>, DecodeError<S::Error>> {

--- a/src/repository/manifest.rs
+++ b/src/repository/manifest.rs
@@ -6,9 +6,6 @@
 //! This module defines the type [`Manifest`] that represents a decoded
 //! manifest and the type [`ManifestContent`] for the content of a validated
 //! manifest, as well as some helper types for accessing the content.
-//!
-//! [`Manifest`]: struct.Manifest.html
-//! [`ManifestContent`]: struct.ManifestContent.html
 
 use std::{borrow, fmt, ops};
 use bcder::{decode, encode};

--- a/src/repository/resources/ipres.rs
+++ b/src/repository/resources/ipres.rs
@@ -295,7 +295,7 @@ impl<'a> fmt::Display for IpBlocksForFamily<'a> {
 
 /// A sequence of address ranges for one address family.
 ///
-/// Values of this type are guaranteed to contain a sequence of `IpBlocks`
+/// Values of this type are guaranteed to contain a sequence of [`IpBlock`]s
 /// that fulfills the requirements of RFC 3779. Specifically, the blocks will
 /// not overlap, will not be consecutive (i.e., there’s at least one address
 /// between neighbouring blocks), will be in order, and anything that can be
@@ -739,7 +739,7 @@ impl IpBlock {
         DisplayV4Block(self)
     }
 
-    /// Returns an object that displays the block as an IPv4 block.
+    /// Returns an object that displays the block as an IPv6 block.
     pub fn display_v6(self) -> DisplayV6Block {
         DisplayV6Block(self)
     }

--- a/src/repository/resources/mod.rs
+++ b/src/repository/resources/mod.rs
@@ -9,8 +9,6 @@
 //! Delegation Extension and [`AsResources`] implements the Autonomous System
 //! Identifier Delegation Extension.
 //!
-//! [`AsResources`]: struct.AsResources.html
-//! [`IpResources`]: struct.IpResources.html
 //! [RFC 3779]: https://tools.ietf.org/html/rfc3779
 //! [RFC 6487]: https://tools.ietf.org/html/rfc6487
 

--- a/src/repository/sigobj.rs
+++ b/src/repository/sigobj.rs
@@ -1270,9 +1270,9 @@ mod signer_test {
 /// [RFC 5652]: https://tools.ietf.org/html/rfc5652
 /// [RFC 6488]: https://tools.ietf.org/html/rfc6488
 /// [RFC 7935]: https://tools.ietf.org/html/rfc7935
-/// [`Cert`]: ../../cert/struct.Cert.html
-/// [`DigestAlgorithm`]: ../../crypto/keys/struct.DigestAlgorithm.html
-/// [`oid`]: ../../oid/index.html
+/// [`Cert`]: super::cert::Cert
+/// [`DigestAlgorithm`]: crate::crypto::digest::DigestAlgorithm
+/// [`oid`]: crate::oid
 pub mod spec { }
 
 

--- a/src/rtr/mod.rs
+++ b/src/rtr/mod.rs
@@ -21,8 +21,8 @@
 //! You can read more about RPKI in [RFC 6480]. RTR is currently specified in
 //! [RFC 8210].
 //!
-//! [`Client`]: client/struct.Client.html
-//! [`Server`]: server/struct.Server.html
+//! [`Client`]: client::Client
+//! [`Server`]: server::Server
 //! [Tokio]: https://crates.io/crates/tokio
 //! [RFC 6480]: https://tools.ietf.org/html/rfc6480
 //! [RFC 8210]: https://tools.ietf.org/html/rfc8210

--- a/src/rtr/server.rs
+++ b/src/rtr/server.rs
@@ -2,9 +2,7 @@
 //!
 //! This module implements a generic RTR server through [`Server`]. The server
 //! receives its data from a type implementing [`PayloadSource`].
-//!
-//! [`Server`]: struct.Server.html
-//! [`VrpSource`]: trait.VrpSource.html
+
 use std::io;
 use futures_util::future;
 use futures_util::pin_mut;
@@ -73,7 +71,7 @@ pub trait PayloadSource: Clone + Sync + Send + 'static {
     /// Returns the current state and an iterator over the full set of VRPs.
     fn full(&self) -> (State, Self::Set);
 
-    /// Returns the current state and an interator over differences in VPRs.
+    /// Returns the current state and an iterator over differences in VPRs.
     ///
     /// The difference is between the state given in `state` and the current
     /// state. If the source cannot provide this difference, for instance
@@ -101,7 +99,7 @@ pub trait PayloadDiff: Sync + Send + 'static {
 
 /// A stream socket to be used for an RTR connection.
 ///
-/// Apart from being abile to read and write asynchronously and being spawned
+/// Apart from being able to read and write asynchronously and being spawned
 /// as an async task, the trait allows additional processing when the client
 /// has successfully updated.
 pub trait Socket: AsyncRead + AsyncWrite + Unpin + Sync + Send + 'static {
@@ -125,8 +123,6 @@ impl Socket for tokio::net::TcpStream { }
 /// a VRP source and serves RTR data. In order to also serve notifications
 /// whenever new data is available, the server uses a notification dispatch
 /// system via the [`Dispatch`] system.
-///
-/// [`Dispatch`]: struct.Dispatch.html
 pub struct Server<Listener, Source> {
     /// The listener socket.
     listener: Listener,
@@ -151,7 +147,7 @@ impl<Listener, Source> Server<Listener, Source> {
     /// Runs the server.
     ///
     /// The asynchronous function will return successfully when the listener
-    /// socket (which is a stream over new connectons) finishes. It will
+    /// socket (which is a stream over new connections) finishes. It will
     /// return with an error if the listener socket errors out.
     pub async fn run<Sock>(mut self) -> Result<(), io::Error>
     where
@@ -202,7 +198,7 @@ impl<Sock, Source> Connection<Sock, Source> {
 
     /// Returns the protocol version we agreed on.
     ///
-    /// If there hasn’t been a negotation yet, returns the lowest protocol
+    /// If there hasn’t been a negotiation yet, returns the lowest protocol
     /// version we support, which currently is 0.
     fn version(&self) -> u8 {
         self.version.unwrap_or(0)

--- a/src/rtr/state.rs
+++ b/src/rtr/state.rs
@@ -4,9 +4,6 @@
 //! particular RTR server. The complete state, encapsulated in the type
 //! [`State`] consists of a sixteen bit session id and a serial number. Since
 //! the serial number follows special rules, it has its own type [`Serial`].
-//!
-//! [`Serial`]: struct.Serial.html
-//! [`State`]: struct.State.html
 
 use std::{cmp, fmt, hash, str};
 use std::time::SystemTime;
@@ -72,8 +69,6 @@ impl State {
     ///
     /// Serial number may wrap but that’s totally fine. See [`Serial`] for
     /// more details.
-    ///
-    /// [`Serial`]: struct.Serial.html
     pub fn inc(&mut self) {
         self.serial = self.serial.add(1)
     }


### PR DESCRIPTION
- Change some links to a format that rustdoc can analyze and warn about when they go stale
- Make more links clickable
- Wrap HTML elements in backticks so they appear in the docs
- Add backticks around a few Rust types
- Fix markdown list with `-` instead of `=`
- Fix various typos in docs and error messages