### PR TITLE
Expose validity in public API

### DIFF
--- a/src/ca/idcert.rs
+++ b/src/ca/idcert.rs
@@ -419,6 +419,10 @@ impl TbsIdCert {
     pub fn subject(&self) -> &Name {
         &self.subject
     }
+
+    pub fn validity(&self) -> &Validity {
+        &self.validity
+    }
 }
 
 /// # Decoding and Encoding


### PR DESCRIPTION
Required for some helpful logging in Krill TA