### PR TITLE
Expose unstable rtr v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,8 @@ softkeys = [ "openssl" ]
 # with OpenSSL
 __windows_ci_all = [ "ca", "rrdp", "rtr", "serde-support" ]
 
+unstable_rtr_version_2 = []
+
 [[bin]]
 name = "readcer"
 required-features = [ "repository" ]

--- a/src/rtr/server.rs
+++ b/src/rtr/server.rs
@@ -26,7 +26,13 @@ use super::state::State;
 /// While the server technically supports version 2 as well, the format of the
 /// ASPA PDU has not yet been agreed upon. Rather than possibly deploying
 /// broken servers, we only announce support for version 0 or 1 for now.
-const MAX_VERSION: u8 = 1;
+const MAX_VERSION: u8 = {
+    if cfg!(feature = "unstable_rtr_version_2") {
+        2
+    } else {
+        1
+    }
+};
 
 //============ Traits ========================================================
 


### PR DESCRIPTION
This was soft removed in https://github.com/NLnetLabs/rpki-rs/pull/281 but it is still a useful implementation for testing and research. A developer can opt into this "unstable" functionality by providing the crate feature.