### PR TITLE
Set RTR server max version to 2.

### DIFF
--- a/src/rtr/server.rs
+++ b/src/rtr/server.rs
@@ -22,11 +22,7 @@ use super::state::State;
 /// The maximum protocol version we support.
 ///
 /// We support all protocol versions from 0 up to and including this value.
-///
-/// While the server technically supports version 2 as well, the format of the
-/// ASPA PDU has not yet been agreed upon. Rather than possibly deploying
-/// broken servers, we only announce support for version 0 or 1 for now.
-const MAX_VERSION: u8 = 1;
+const MAX_VERSION: u8 = 2;
 
 //============ Traits ========================================================
 


### PR DESCRIPTION
This PR sets the maximum supported RTR version in the RTR server to 2.

Thanks to @devsnek for pointing out that we forget to do that.