### PR TITLE
Fix new hidden lifetime warning.

### DIFF
--- a/src/repository/aspa.rs
+++ b/src/repository/aspa.rs
@@ -228,7 +228,7 @@ impl ProviderAsSet {
         }
     }
 
-    pub fn iter(&self) -> ProviderAsIter {
+    pub fn iter(&self) -> ProviderAsIter<'_> {
         ProviderAsIter(self.captured.as_slice().into_source())
     }
 

--- a/src/repository/resources/ipres.rs
+++ b/src/repository/resources/ipres.rs
@@ -550,13 +550,13 @@ impl IpBlocks {
 
     /// Returns an IpBlocksForFamily for IPv4 for this,
     /// to help formatting.
-    pub fn as_v4(&self) -> IpBlocksForFamily {
+    pub fn as_v4(&self) -> IpBlocksForFamily<'_> {
         IpBlocksForFamily::v4(self)
     }
 
     /// Returns an IpBlocksForFamily for IPv4 for this,
     /// to help formatting.
-    pub fn as_v6(&self) -> IpBlocksForFamily {
+    pub fn as_v6(&self) -> IpBlocksForFamily<'_> {
         IpBlocksForFamily::v6(self)
     }
 }

--- a/src/repository/roa.rs
+++ b/src/repository/roa.rs
@@ -285,7 +285,7 @@ impl RoaIpAddresses {
         self.0.is_empty()
     }
 
-    pub fn iter(&self) -> RoaIpAddressIter {
+    pub fn iter(&self) -> RoaIpAddressIter<'_> {
         RoaIpAddressIter(self.0.as_slice().into_source())
     }
 

--- a/src/repository/tal.rs
+++ b/src/repository/tal.rs
@@ -107,7 +107,7 @@ impl Tal {
 }
 
 impl Tal {
-    pub fn uris(&self) -> ::std::slice::Iter<TalUri> {
+    pub fn uris(&self) -> ::std::slice::Iter<'_, TalUri> {
         self.uris.iter()
     }
 

--- a/src/resources/asn.rs
+++ b/src/resources/asn.rs
@@ -306,7 +306,7 @@ impl SmallAsnSet {
         Self(vec)
     }
 
-    pub fn iter(&self) -> SmallSetIter {
+    pub fn iter(&self) -> SmallSetIter<'_> {
         self.0.iter().cloned()
     }
 

--- a/src/rtr/payload.rs
+++ b/src/rtr/payload.rs
@@ -204,7 +204,7 @@ impl Payload {
     }
 
     /// Converts a reference to payload into a payload reference.
-    pub fn as_ref(&self) -> PayloadRef {
+    pub fn as_ref(&self) -> PayloadRef<'_> {
         match self {
             Payload::Origin(origin) => PayloadRef::Origin(*origin),
             Payload::RouterKey(key) => PayloadRef::RouterKey(key),

--- a/src/rtr/pdu.rs
+++ b/src/rtr/pdu.rs
@@ -1875,19 +1875,19 @@ mod test {
     fn provider_count() {
         assert_eq!(
             ProviderAsns::try_from_iter(
-                std::iter::repeat_n(Asn::from(0), ProviderAsns::MAX_COUNT - 1)
+                iter::repeat_n(Asn::from(0), ProviderAsns::MAX_COUNT - 1)
             ).unwrap().asn_count(),
             (ProviderAsns::MAX_COUNT - 1) as u16,
         );
         assert_eq!(
             ProviderAsns::try_from_iter(
-                std::iter::repeat_n(Asn::from(0), ProviderAsns::MAX_COUNT)
+                iter::repeat_n(Asn::from(0), ProviderAsns::MAX_COUNT)
             ).unwrap().asn_count(),
             ProviderAsns::MAX_COUNT as u16,
         );
         assert!(
             ProviderAsns::try_from_iter(
-                std::iter::repeat_n(Asn::from(0), ProviderAsns::MAX_COUNT + 1)
+                iter::repeat_n(Asn::from(0), ProviderAsns::MAX_COUNT + 1)
             ).is_err()
         );
     }

--- a/src/rtr/server.rs
+++ b/src/rtr/server.rs
@@ -81,13 +81,13 @@ pub trait PayloadSource: Clone + Sync + Send + 'static {
 /// A type providing access to a complete payload set.
 pub trait PayloadSet: Sync + Send + 'static {
     /// Returns the next element in the payload set.
-    fn next(&mut self) -> Option<PayloadRef>;
+    fn next(&mut self) -> Option<PayloadRef<'_>>;
 }
 
 /// A type providing access to a diff between payload sets.
 pub trait PayloadDiff: Sync + Send + 'static {
     /// Returns the next element in the diff.
-    fn next(&mut self) -> Option<(PayloadRef, Action)>;
+    fn next(&mut self) -> Option<(PayloadRef<'_>, Action)>;
 }
 
 

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -171,7 +171,7 @@ impl Rsync {
     /// Since host names are case-insensitive, the authority part can be
     /// provided in different ways. This returns a version of the authority
     /// with all ASCII letters in lowercase.
-    pub fn canonical_authority(&self) -> Cow<str> {
+    pub fn canonical_authority(&self) -> Cow<'_, str> {
         let authority = self.authority();
         if authority.as_bytes().iter().any(u8::is_ascii_uppercase) {
             Cow::Owned(authority.to_ascii_lowercase())
@@ -197,7 +197,7 @@ impl Rsync {
     ///
     /// This is the same as the module but with the authority in canonical
     /// form.
-    pub fn canonical_module(&self) -> Cow<str> {
+    pub fn canonical_module(&self) -> Cow<'_, str> {
         if self.authority().as_bytes().iter().any(u8::is_ascii_uppercase) {
             let mut res = String::with_capacity(self.path_start);
             res.push_str("rsync://");
@@ -588,7 +588,7 @@ impl Https {
     /// Since host names are case-insensitive, the authority part can be
     /// provided in different ways. This returns a version of the authority
     /// with all ASCII letters in lowercase.
-    pub fn canonical_authority(&self) -> Cow<str> {
+    pub fn canonical_authority(&self) -> Cow<'_, str> {
         let authority = self.authority();
         if authority.as_bytes().iter().any(u8::is_ascii_uppercase) {
             Cow::Owned(authority.to_ascii_lowercase())

--- a/src/util/base64.rs
+++ b/src/util/base64.rs
@@ -62,7 +62,7 @@ impl Xml {
 
     pub fn decode_reader(
         self, input: &str,
-    ) -> XmlDecoderReader {
+    ) -> XmlDecoderReader<'_> {
         XmlDecoderReader(
             base64::read::DecoderReader::new(
                 SkipWhitespace::new(input),

--- a/src/xml/decode.rs
+++ b/src/xml/decode.rs
@@ -104,7 +104,7 @@ impl<'b, 'n> Element<'b, 'n> {
     }
 
     /// Returns the name of the element.
-    pub fn name(&self) -> Name {
+    pub fn name(&self) -> Name<'_, '_> {
         Name::new(
             self.ns.map(|ns| ns.0),
             self.start.local_name().into_inner()
@@ -494,11 +494,11 @@ impl AttrValue<'_> {
 pub struct Text<'a>(quick_xml::events::BytesText<'a>);
 
 impl Text<'_> {
-    pub fn to_utf8(&self) -> Result<Cow<str>, Error> {
+    pub fn to_utf8(&self) -> Result<Cow<'_, str>, Error> {
         Ok(self.0.unescape()?)
     }
 
-    pub fn to_ascii(&self) -> Result<Cow<str>, Error> {
+    pub fn to_ascii(&self) -> Result<Cow<'_, str>, Error> {
         // XXX Shouldn’t this reject non-ASCII Unicode?
         Ok(self.0.unescape()?)
     }


### PR DESCRIPTION
This PR fixes the new “hiding a lifetime that's elided elsewhere is confusing” introduced in Rust 1.89.