### PR TITLE
Implement source for decode::Error and ProcessError

### DIFF
--- a/src/rrdp.rs
+++ b/src/rrdp.rs
@@ -1623,7 +1623,14 @@ impl fmt::Display for ProcessError {
     }
 }
 
-impl error::Error for ProcessError { }
+impl error::Error for ProcessError { 
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            ProcessError::Io(error) => Some(error),
+            ProcessError::Xml(error) => Some(error),
+        }
+    }
+}
 
 
 //============ Tests =========================================================

--- a/src/xml/decode.rs
+++ b/src/xml/decode.rs
@@ -612,4 +612,12 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error { } 
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Error::Xml(error) => Some(error),
+            Error::XmlAttr(attr_error) => Some(attr_error),
+            Error::Malformed => None,
+        }
+    }
+ } 


### PR DESCRIPTION
In order to allow bubbling up (or down) the error source