### PR TITLE
Fix Key Usage parsing.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 arbitrary       = { version = "1", optional = true, features = ["derive"] }
 base64          = "0.22"
-bcder           = { version = "0.7.3", optional = true }
+bcder           = { optional = true, git = "https://github.com/NLnetLabs/bcder.git" }
 bytes           = "1.0"
 chrono          = { version = "0.4.35", features = [ "serde" ] }
 futures-util    = { version = "0.3", optional = true }

--- a/src/repository/cert.rs
+++ b/src/repository/cert.rs
@@ -1832,10 +1832,10 @@ impl TbsCert {
         else {
             *key_usage = Some({
                 let bits = BitString::take_from(cons)?;
-                if bits.bit(5) && bits.bit(6) {
+                if bits.bit_len() == 7 && bits.octet(0) == 0b0000_0110 {
                     Ok(KeyUsage::Ca)
                 }
-                else if bits.bit(0) {
+                else if bits.bit_len() == 1 && bits.bit(0) {
                     Ok(KeyUsage::Ee)
                 }
                 else {


### PR DESCRIPTION
This PR fixes parsing of Key Usage extension of resource certificates. Previously, parsing only checked that the required bits were set but it didn’t check that all other bits were zero.

I checked the change against the current version of the public RPKI and it does not affect any current objects, so it should be safe to apply in non-strict mode as well.

This issue was reported by Zizhi Shang, Zhechao Lin, Jiahao Cao, Yangyang Wang, and Mingwei Xu of  the Institute for Network Sciences and Cyberspace (INSC), Tsinghua University.
