### PR TITLE
Add missing check for #342

### DIFF
--- a/src/repository/manifest.rs
+++ b/src/repository/manifest.rs
@@ -420,6 +420,10 @@ impl FileAndHash<Bytes, Bytes> {
         cons: &mut decode::Constructed<S>
     ) -> Result<Option<()>, DecodeError<S::Error>> {
         cons.take_opt_sequence(|cons| {
+            let file = Ia5String::take_from(cons)?.into_bytes();
+            if let Err(err) = Self::validate_file_name(&file) {
+                return Err(cons.content_err(err)); 
+            }
             let _ = Ia5String::take_from(cons)?;
             BitString::skip_in(cons)?;
             Ok(())

--- a/src/repository/manifest.rs
+++ b/src/repository/manifest.rs
@@ -424,7 +424,6 @@ impl FileAndHash<Bytes, Bytes> {
             if let Err(err) = Self::validate_file_name(&file) {
                 return Err(cons.content_err(err)); 
             }
-            let _ = Ia5String::take_from(cons)?;
             BitString::skip_in(cons)?;
             Ok(())
         })
@@ -635,6 +634,7 @@ mod test {
         assert!(!test_name("slash//es.mft"));
         assert!(test_name("unknownextension.abc"));
         assert!(!test_name("new\r\nlines.gbr"));
+        assert!(test_name("dashes-and_underscores.gbr"));
         assert!(!test_name("multiple.dots.in.file.name.roa"));
         assert!(!test_name("too_long_extension.koen"));
     }

--- a/src/repository/manifest.rs
+++ b/src/repository/manifest.rs
@@ -473,12 +473,12 @@ impl FileAndHash<Bytes, Bytes> {
 
         // Now you could check whether this extension matches one in the list 
         // ["asa", "cer", "crl", "gbr", "mft", "roa", "sig", "tak"],  but that 
-        // would be brittle, so as long as it is three valid characters we 
-        // will accept it.
+        // would be brittle, so as long as it is three valid letters we will
+        // accept it.
         string.len() == 3 &&
-            Self::valid_rfc9286_character(string[0]) &&
-            Self::valid_rfc9286_character(string[1]) &&
-            Self::valid_rfc9286_character(string[2])
+            string[0].is_ascii_alphabetic() &&
+            string[1].is_ascii_alphabetic() &&
+            string[2].is_ascii_alphabetic()
     }
 }
 

--- a/src/repository/manifest.rs
+++ b/src/repository/manifest.rs
@@ -447,9 +447,7 @@ impl FileAndHash<Bytes, Bytes> {
     fn valid_rfc9286_character(c: u8) -> bool {
         c == b'-' || //-
         c == b'_' || //_
-        (c >= 0x30 && c <= 0x39) || //0-9
-        (c >= 0x41 && c <= 0x5A) || //A-Z
-        (c >= 0x61 && c <= 0x7A) //a-z
+        c.is_ascii_alphanumeric()
     }
 
     /// Check whether the file name matches RFC 9286 4.2.2:

--- a/src/repository/manifest.rs
+++ b/src/repository/manifest.rs
@@ -453,7 +453,7 @@ impl FileAndHash<Bytes, Bytes> {
         fn valid_rfc9286_character(c: u8) -> bool {
             c == b'-' || c == b'_' || c.is_ascii_alphanumeric()
         }
-        
+
         let mut n = name;
         while let Some((c, tail)) = n.split_first() {
             n = tail;
@@ -461,7 +461,7 @@ impl FileAndHash<Bytes, Bytes> {
                 break;
             } 
             else if !valid_rfc9286_character(*c) {
-                return Err("Manifest filename is not RFC 9286 4.2.2 compliant");
+                return Err("manifest filename is not RFC 9286 4.2.2 compliant");
             }
         }
 
@@ -469,10 +469,11 @@ impl FileAndHash<Bytes, Bytes> {
         // ["asa", "cer", "crl", "gbr", "mft", "roa", "sig", "tak"],  but that 
         // would be brittle, so as long as it is three valid letters we will
         // accept it. 
-        match n.len() == 3 && n.iter().all(|c| c.is_ascii_alphabetic()) {
-            true => Ok(()),
-            false => Err("Manifest extension is not RFC 9286 4.2.2 compliant")
+        if n.len() != 3 || !n.iter().all(|c| c.is_ascii_alphabetic()) {
+            return Err("manifest extension is not RFC 9286 4.2.2 compliant");
         }
+
+        Ok(())
     }
 }
 

--- a/src/repository/manifest.rs
+++ b/src/repository/manifest.rs
@@ -674,8 +674,8 @@ mod signer_test {
             12u64.into(), Time::now(), Time::next_week(),
             DigestAlgorithm::default(),
             [
-                FileAndHash::new(b"file".as_ref(), b"hash".as_ref()),
-                FileAndHash::new(b"file".as_ref(), b"hash".as_ref()),
+                FileAndHash::new(b"file.cer".as_ref(), b"hash".as_ref()),
+                FileAndHash::new(b"file.cer".as_ref(), b"hash".as_ref()),
             ].iter()
         );
 


### PR DESCRIPTION
Before: 
```
(.venv) koen@beta:~/Code/routinator/target/debug$ ./routinator -c routinator.conf -vv --log-repository-issues --no-rir-tals --extra-tals-dir=tals vrps
[WARN] Using config file /home/koen/Code/routinator/target/debug/routinator.conf.
[INFO] Using the following TALs:
[INFO]   * koenvh-R
[DEBUG] Found valid trust anchor https://r-bb0b035d-bf9a-414b-b30e-e90964f3e3dc.rprp.nlnetlabs.net/ta/ta.cer. Processing.
[DEBUG] RRDP https://r-bb0b035d-bf9a-414b-b30e-e90964f3e3dc.rprp.nlnetlabs.net/notification.xml: Serials: us 1337, them 1337.
[DEBUG] RRDP https://r-bb0b035d-bf9a-414b-b30e-e90964f3e3dc.rprp.nlnetlabs.net/notification.xml: Delta update completed.

thread '<unnamed>' panicked at /home/koen/.cargo/git/checkouts/rpki-rs-7850b2693f9d4f2b/d2fcbe9/src/repository/manifest.rs:371:12:
called `Result::unwrap()` on an `Err` value: DecodeError { inner: Content { error: ContentError(manifest filename is not RFC 9286 4.2.2 compliant), pos: Pos(2) } }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'main' panicked at src/engine.rs:458:9:
a scoped thread panicked
```

After:
```
(.venv) koen@beta:~/Code/routinator/target/debug$ ./routinator -c routinator.conf -vv --log-repository-issues --no-rir-tals --extra-tals-dir=tals vrps
[WARN] Using config file /home/koen/Code/routinator/target/debug/routinator.conf.
[INFO] Using the following TALs:
[INFO]   * koenvh-R
[DEBUG] Found valid trust anchor https://r-bb0b035d-bf9a-414b-b30e-e90964f3e3dc.rprp.nlnetlabs.net/ta/ta.cer. Processing.
[DEBUG] RRDP https://r-bb0b035d-bf9a-414b-b30e-e90964f3e3dc.rprp.nlnetlabs.net/notification.xml: updating from snapshot.
[DEBUG] RRDP https://r-bb0b035d-bf9a-414b-b30e-e90964f3e3dc.rprp.nlnetlabs.net/notification.xml: snapshot update completed.
[INFO] rsync://r-bb0b035d-bf9a-414b-b30e-e90964f3e3dc.rprp.nlnetlabs.net/repository/: failed to decode manifest rsync://r-bb0b035d-bf9a-414b-b30e-e90964f3e3dc.rprp.nlnetlabs.net/repository/koenvh.mft.
[INFO] rsync://r-bb0b035d-bf9a-414b-b30e-e90964f3e3dc.rprp.nlnetlabs.net/repository/: no valid manifest rsync://r-bb0b035d-bf9a-414b-b30e-e90964f3e3dc.rprp.nlnetlabs.net/repository/koenvh.mft found.
ASN,IP Prefix,Max Length,Trust Anchor
```