### PR TITLE
Fix panic in ASN parsing

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "rpki"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "base64",
  "bcder",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -26,3 +26,10 @@ name = "decode_objects"
 path = "fuzz_targets/decode_objects.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "parse_asn"
+path = "fuzz_targets/parse_asn.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/parse_asn.rs
+++ b/fuzz/fuzz_targets/parse_asn.rs
@@ -3,8 +3,6 @@
 use libfuzzer_sys::fuzz_target;
 use std::str::FromStr;
 
-fuzz_target!(|data: &[u8]| {
-    if let Ok(s) = std::str::from_utf8(data) {
-        let _ = rpki::resources::Asn::from_str(s);
-    }
+fuzz_target!(|data: &str| {
+    let _ = rpki::resources::Asn::from_str(data);
 });

--- a/fuzz/fuzz_targets/parse_asn.rs
+++ b/fuzz/fuzz_targets/parse_asn.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use std::str::FromStr;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = rpki::resources::Asn::from_str(s);
+    }
+});

--- a/src/resources/asn.rs
+++ b/src/resources/asn.rs
@@ -99,16 +99,20 @@ impl FromStr for Asn {
     type Err = ParseAsnError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = if s.len() > 2 && s[..2].eq_ignore_ascii_case("as") {
-            &s[2..]
-        } else {
-            s
-        };
-
-        u32::from_str(s).map(Asn).map_err(|_| ParseAsnError)
+        u32::from_str(strip_as(s))
+            .map(Asn)
+            .map_err(|_| ParseAsnError)
     }
 }
 
+fn strip_as(s: &str) -> &str {
+    if let Some((prefix, rest)) = s.split_at_checked(2) {
+        if prefix.eq_ignore_ascii_case("as") {
+            return rest;
+        }
+    }
+    s
+}
 
 //--- Serialize and Deserialize
 
@@ -627,6 +631,11 @@ mod tests {
         assert_eq!("".parse::<Asn>(), Err(ParseAsnError));
         assert_eq!("-1234".parse::<Asn>(), Err(ParseAsnError));
         assert_eq!("4294967296".parse::<Asn>(), Err(ParseAsnError));
+
+        // Code point 0x80 is outside of ASCII and therefore is more
+        // than two bytes. Splitting on 2 bytes would result in a
+        // panic.
+        assert_eq!("a\u{80}123".parse::<Asn>(), Err(ParseAsnError));
     }
 
 


### PR DESCRIPTION
Includes a fuzz target for ASN parsing to verify that it works and a test case with a character that takes 2 bytes in UTF-8.