### PR TITLE
Public CrlEntry fields and conversion of Serial to num-bigint types.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "rpki"
-version = "0.19.2"
+version = "0.20.0-dev"
 dependencies = [
  "arbitrary",
  "aws-lc-rs",
@@ -1109,6 +1128,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
+ "num-bigint",
  "openssl",
  "quick-xml",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,20 +18,22 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-arbitrary       = { version = "1", optional = true, features = ["derive"] }
 base64          = "0.22"
-bcder           = { version = "0.7.6", optional = true }
 bytes           = "1.11"
+log             = "0.4.7"
+uuid            = "1.1"
+
+arbitrary       = { version = "1", optional = true, features = ["derive"] }
+bcder           = { version = "0.7.6", optional = true }
 chrono          = { version = "0.4.35", features = [ "serde" ] }
 futures-util    = { version = "0.3", optional = true }
-log             = "0.4.7"
+num-bigint      = { version = "0.4.6", optional = true }
 openssl         = { version = "0.10.23", optional = true }
 quick-xml       = { version = "0.39.0", optional = true }
 aws-lc-rs       = { version = "1.16.2", optional = true }
 serde           = { version = "1.0.103", optional = true, features = [ "derive" ] }
 serde_json      = { version = "1.0.40", optional = true }
 tokio           = { version = "1.0", optional = true, features = ["io-util",  "net", "rt", "sync", "time"] }
-uuid            = "1.1"
 
 [dev-dependencies]
 serde_json      = "1.0.40"

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,8 +7,14 @@ Breaking changes
 * Renamed the `OpenSslSigner` to `SoftSigner` since it doesn’t use OpenSSL
   any more. ([#358])
 
+Improvements
+
+* Made the fields of `CrlEntry` public. ([#368])
+
 New
 
+* Added optional conversion of `x509::Serial` to [num-bigint] types.
+  ([#368])
 * Removed the dependencies on _ring_ and OpenSSL and replaced them with
   [aws-lc-rs]. ([#358])
 
@@ -20,7 +26,9 @@ Other changes
 
 [#358]: https://github.com/NLnetLabs/rpki-rs/pull/358
 [#359]: https://github.com/NLnetLabs/rpki-rs/pull/359
+[#368]: https://github.com/NLnetLabs/rpki-rs/pull/368
 [aws-lc-rs]: https://crates.io/crates/aws-lc-rs
+[num-bigint]: https://crates.io/crates/num-bigint
 
 
 ## 0.19.2

--- a/src/repository/crl.rs
+++ b/src/repository/crl.rs
@@ -604,10 +604,10 @@ impl Iterator for RevokedCertificatesIter {
 #[derive(Clone, Copy, Debug)]
 pub struct CrlEntry {
     /// The serial number of the revoked certificate.
-    user_certificate: Serial,
+    pub user_certificate: Serial,
 
     /// The time of revocation.
-    revocation_date: Time,
+    pub revocation_date: Time,
 }
 
 impl CrlEntry {

--- a/src/repository/x509.rs
+++ b/src/repository/x509.rs
@@ -494,6 +494,34 @@ impl From<Serial> for String {
     }
 }
 
+#[cfg(feature = "num-bigint")]
+impl From<Serial> for num_bigint::BigInt {
+    fn from(serial: Serial) -> Self {
+        Self::from_bytes_be(num_bigint::Sign::Plus, &serial.0)
+    }
+}
+
+#[cfg(feature = "num-bigint")]
+impl From<Serial> for num_bigint::BigUint {
+    fn from(serial: Serial) -> Self {
+        Self::from_bytes_be(&serial.0)
+    }
+}
+
+#[cfg(feature = "num-bigint")]
+impl num_bigint::ToBigInt for Serial {
+    fn to_bigint(&self) -> Option<num_bigint::BigInt> {
+        Some(From::from(*self))
+    }
+}
+
+#[cfg(feature = "num-bigint")]
+impl num_bigint::ToBigUint for Serial {
+    fn to_biguint(&self) -> Option<num_bigint::BigUint> {
+        Some(From::from(*self))
+    }
+}
+
 impl FromStr for Serial {
     type Err = RepresentationError;
 


### PR DESCRIPTION
This PR makes the two fields of `CrlEntry` public and adds optional conversions for the `Serial` type to the integers in the num-bigint crate.

Fixes #364.