### PR TITLE
[0.19] Upgrade to quick-xml 0.39.4 and add regression test.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ chrono          = { version = "0.4.35", features = [ "serde" ] }
 futures-util    = { version = "0.3", optional = true }
 log             = "0.4.7"
 openssl         = { version = "0.10.23", optional = true }
-quick-xml       = { version = "0.39.0", optional = true }
+quick-xml       = { version = "0.39.4", optional = true }
 ring            = { version = "0.17.6", optional = true }
 serde           = { version = "1.0.103", optional = true, features = [ "derive" ] }
 serde_json      = { version = "1.0.40", optional = true }

--- a/src/rrdp.rs
+++ b/src/rrdp.rs
@@ -1951,4 +1951,13 @@ mod test {
             ["https://foo.bar/", "https://foo.local/4"],
         ));
     }
+
+    /// Regression test for an panic in quick-xml 0.39.0.
+    #[test]
+    fn doctype_panic_regression() {
+        let reader = std::io::BufReader::with_capacity(
+            8, "<!d[<>23456789".as_bytes()
+        );
+        let _  = NotificationFile::parse(reader);
+    }
 }


### PR DESCRIPTION
This PR fixes an XML parsing vulnerability based on https://github.com/tafia/quick-xml/issues/950.

The issue fixed by this PR has been assigned CVE-2026-49235.